### PR TITLE
Unbundle index

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -76,12 +76,17 @@ class VGCGLTest(TestCase):
         '''
         subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/NA12877.lrc_kir.bam.small.fq', self.workdir])
         subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/LRC_KIR_chrom_name_chop_100.small.vg', self.workdir])
-        subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/lrc_kir_index.tar.gz', self.workdir])
+        subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/LRC_KIR_chrom_name_chop_100.small.vg.xg', self.workdir])
+        subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/LRC_KIR_chrom_name_chop_100.small.vg.gcsa', self.workdir])
+        subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/LRC_KIR_chrom_name_chop_100.small.vg.gcsa.lcp', self.workdir])
         self.sample_reads = os.path.join(self.workdir, 'NA12877.lrc_kir.bam.small.fq')
         self.test_vg_graph = os.path.join(self.workdir, 'LRC_KIR_chrom_name_chop_100.small.vg')
-        self.test_index = os.path.join(self.workdir, 'lrc_kir_index.tar.gz')
+        self.test_xg_index = os.path.join(self.workdir, 'LRC_KIR_chrom_name_chop_100.small.vg.xg')
+        self.test_gcsa_index = os.path.join(self.workdir, 'LRC_KIR_chrom_name_chop_100.small.vg.gcsa')
+        
         self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
-                                   self.outstore,  '--gcsa_index', self.test_index, '--path_name', '19', '--path_size', '50000')
+                  self.outstore,  '--gcsa_index', self.test_gcsa_index,
+                  '--xg_index', self.test_xg_index, '--path_name', '19', '--path_size', '50000')
         self._assertOutput('NA12877_19.vcf', self.outstore)
 
     @skip("Skipping MHC test")
@@ -90,9 +95,9 @@ class VGCGLTest(TestCase):
         '''
         self.sample_reads = 's3://cgl-pipeline-inputs/vg_cgl/ci/NA12877.mhc.bam.small.fq'
         self.test_vg_graph = 's3://cgl-pipeline-inputs/vg_cgl/ci/MHC_chrom_name_chop_100.small.vg'
-        self.test_index = 's3://cgl-pipeline-inputs/vg_cgl/ci/mhc_index.tar.gz'
+        self.test_gcsa_index = 's3://cgl-pipeline-inputs/vg_cgl/ci/MHC_chrom_name_chop_100.small.vg.gcsa'
         self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
-                                   self.outstore,  '--gcsa_index', self.test_index, '--path_name', '6', '--path_size', '50000')
+                                   self.outstore,  '--gcsa_index', self.test_gcsa_index, '--path_name', '6', '--path_size', '50000')
         self._assertOutput('NA12877_6.vcf', self.outstore)
 
     @skip("Skipping SMA test")
@@ -101,10 +106,8 @@ class VGCGLTest(TestCase):
         '''
         subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/NA12877.sma.bam.small.fq', self.workdir])
         subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/SMA_chrom_name_chop_100.small.vg', self.workdir])
-        subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/sma_index.tar.gz', self.workdir])
         self.sample_reads = os.path.join(self.workdir, 'NA12877.sma.bam.small.fq')
         self.test_vg_graph = os.path.join(self.workdir, 'SMA_chrom_name_chop_100.small.vg')
-        self.test_index = os.path.join(self.workdir, 'sma_index.tar.gz')
         self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
                                    self.outstore, '--path_name', '5', '--path_size', '50000')
         self._assertOutput('NA12877_5.vcf', self.outstore)

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -161,6 +161,28 @@ def clean_toil_path(path):
     else:
         return path
 
+def import_to_store(toil, options, path, use_out_store = None,
+                    out_store_key = None):
+    """
+    Imports a path into the File or IO store
+
+    Abstract all store writing here so we can switch to the out_store
+    when we want to checkpoint an intermeidate file for output
+    or just have all intermediate files in the outstore for debugging.
+    
+    Returns the id in job's file store if use_out_store is True
+    otherwise a key (up to caller to make sure its unique)
+    in the out_store
+
+    By default options.force_outstore is used to toggle between file and 
+    i/o store.  This will be over-ridden by the use_out_store parameter 
+    if the latter is not None
+    """
+    if use_out_store is True or (use_out_store is None and options.force_outstore is True):
+        return write_to_store(None, options, path, use_out_store, out_store_key)
+    else:
+        return toil.importFile(clean_toil_path(path))
+    
 def write_to_store(job, options, path, use_out_store = None,
                    out_store_key = None):
     """

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -73,9 +73,6 @@ def index_parse_args(parser):
         help="size of kmers to use in indexing and mapping")
     parser.add_argument("--reindex", default=False, action="store_true",
         help="don't re-use existing indexed graphs")
-    parser.add_argument("--index_mode", choices=["rocksdb", "gcsa-kmer",
-        "gcsa-mem"], default="gcsa-mem",
-        help="type of vg index to use for mapping")
     parser.add_argument("--include_pruned", action="store_true",
         help="use the pruned graph in the index")
     parser.add_argument("--include_primary", action="store_true",
@@ -83,175 +80,168 @@ def index_parse_args(parser):
     parser.add_argument("--index_cores", type=int, default=3,
         help="number of threads during the indexing step")
 
-def run_indexing(job, options, inputGraphFileID):
+def run_gcsa_indexing(job, options, inputGraphFileID):
     """
-    Create a directory with the gcsa and xg indexe files and tar it up
-    Return a tuple of its name and id
+    Make the gcsa2 index. Return its store id
     """
     
-    RealTimeLogger.get().info("Starting indexing...")
+    RealTimeLogger.get().info("Starting gcsa indexing...")
     
-    # Set up the IO stores each time, since we can't unpickle them on Azure for
-    # some reason.
-    out_store = IOStore.get(options.out_store)
-
-    graph_file = os.path.basename(options.vg_graph)
+    graph_name = os.path.basename(options.vg_graph)
 
     # Define work directory for docker calls
     work_dir = job.fileStore.getLocalTempDir()
-    
-    # Download local input files from the remote storage container
-    graph_dir = work_dir
-    robust_makedirs(graph_dir)
-    
-    graph_filename = "{}/graph.vg".format(graph_dir)
-    read_from_store(job, options, inputGraphFileID, graph_filename, use_out_store = False)    
+
+    # Our local copy of the graph
+    graph_filename = os.path.join(work_dir, graph_name)
+    read_from_store(job, options, inputGraphFileID, graph_filename)    
     
     # Now run the indexer.
-    RealTimeLogger.get().info("Indexing {}".format(options.vg_graph))
+    RealTimeLogger.get().info("GCSA Indexing {}".format(options.vg_graph))
             
-    if options.index_mode == "rocksdb":
-        # Make the RocksDB index
-        command = ['index', '-s', '-k', str(options.kmer_size), '-e', str(options.edge_max), '-t', str(job.cores), os.path.basename(graph_filename), os.path.basename('{}/{}.index'.format(graph_dir, graph_file))]
-        options.drunner.call(command, work_dir=work_dir)
+    # We want a GCSA2/xg index. We have to prune the graph ourselves.
+    # See <https://github.com/vgteam/vg/issues/286>.
 
-    elif (options.index_mode == "gcsa-kmer" or
-        options.index_mode == "gcsa-mem"):
-        # We want a GCSA2/xg index. We have to prune the graph ourselves.
-        # See <https://github.com/vgteam/vg/issues/286>.
+    # What will we use as our temp combined graph file (containing only
+    # the bits of the graph we want to index, used for deduplication)?
+    to_index_filename = os.path.join(work_dir, "to_index.vg")
 
-        # What will we use as our temp combined graph file (containing only
-        # the bits of the graph we want to index, used for deduplication)?
-        to_index_filename = "{}/to_index.vg".format(
-            work_dir)
+    # Where will we save the kmers?
+    kmers_filename = os.path.join(work_dir, "kmers.tsv")
 
-        # Where will we save the kmers?
-        kmers_filename = "{}/index.graph".format(
-            work_dir)
+    with open(to_index_filename, "w") as to_index_file:
+        if options.include_pruned:
+            RealTimeLogger.get().info("Pruning {} to {}".format(
+                graph_filename, to_index_filename))
 
-        
-        with open(to_index_filename, "w") as to_index_file:
+            # Prune out hard bits of the graph
+            # and complex regions
+            # and short disconnected chunks
+            command = [['vg', 'mod', '-p', '-l', str(options.kmer_size), '-t', str(job.cores), '-e',
+                        str(options.edge_max), os.path.basename(graph_filename)]]
+            command.append(['vg', 'mod', '-S', '-l', str(options.kmer_size * 2), '-t', str(job.cores)])
+            options.drunner.call(command, work_dir=work_dir, outfile=to_index_file)
 
-            if options.include_pruned:
+        if options.include_primary:
 
-                RealTimeLogger.get().info("Pruning {} to {}".format(
-                    graph_filename, to_index_filename))
+            # Then append in the primary path. Since we don't knoiw what
+            # "it's called, we retain "ref" and all the 19", "6", etc paths
+            # "from 1KG.
 
-                # Prune out hard bits of the graph
-                # and complex regions
-                # and short disconnected chunks
-                command = [['vg', 'mod', '-p', '-l', str(options.kmer_size), '-t', str(job.cores), '-e', str(options.edge_max), os.path.basename(graph_filename)]]
-                command.append(['vg', 'mod', '-S', '-l', str(options.kmer_size * 2), '-t', str(job.cores)])
-                options.drunner.call(command, work_dir=work_dir, outfile=to_index_file)
+            RealTimeLogger.get().info(
+                "Adding primary path to {}".format(to_index_filename))
+            # See
+            # https://github.com/vgteam/vg/issues/318#issuecomment-215102199
 
-            if options.include_primary:
+            # Generate all the paths names we might have for primary paths.
+            # It should be "ref" but some graphs don't listen
+            RealTimeLogger.get().info("OPTIONS.PATH_NAME: {}".format(options.path_name[0]))
+            RealTimeLogger.get().info("CHR IN OPTIONS.PATH_NAME: {}".format('chr' in options.path_name[0]))
+            if 'chr' in options.path_name[0]:
+                ref_names = (["ref", "chrx", "chrX", "chry", "chrY", "chrm", "chrM"] +
+                    ['chr'+str(x) for x in xrange(1, 23)])
+            else:
+                ref_names = (["ref", "x", "X", "y", "Y", "m", "M"] +
+                    [str(x) for x in xrange(1, 23)])
+            RealTimeLogger.get().info("REF_NAMES: {}".format(ref_names))
+            ref_options = []
+            for name in ref_names:
+                # Put each in a -r option to retain the path
+                ref_options.append("-r")
+                ref_options.append(name)
 
-                # Then append in the primary path. Since we don't knoiw what
-                # "it's called, we retain "ref" and all the 19", "6", etc paths
-                # "from 1KG.
-
-                RealTimeLogger.get().info(
-                    "Adding primary path to {}".format(to_index_filename))
-            
-                RealTimeLogger.get().info(
-                    "to_index_file: {}".format(to_index_file))
-                # See
-                # https://github.com/vgteam/vg/issues/318#issuecomment-215102199
-
-                # Generate all the paths names we might have for primary paths.
-                # It should be "ref" but some graphs don't listen
-                RealTimeLogger.get().info("OPTIONS.PATH_NAME: {}".format(options.path_name[0]))
-                RealTimeLogger.get().info("CHR IN OPTIONS.PATH_NAME: {}".format('chr' in options.path_name[0]))
-                if 'chr' in options.path_name[0]:
-                    ref_names = (["ref", "chrx", "chrX", "chry", "chrY", "chrm", "chrM"] +
-                        ['chr'+str(x) for x in xrange(1, 23)])
-                else:
-                    ref_names = (["ref", "x", "X", "y", "Y", "m", "M"] +
-                        [str(x) for x in xrange(1, 23)])
-                RealTimeLogger.get().info("REF_NAMES: {}".format(ref_names))
-                ref_options = []
-                for name in ref_names:
-                    # Put each in a -r option to retain the path
-                    ref_options.append("-r")
-                    ref_options.append(name)
-
-                # Retain only the specified paths (only one should really exist)
-                command = ['vg', 'mod', '-N'] + ref_options + ['-t', str(job.cores), os.path.basename(graph_filename)]
-                options.drunner.call(command, work_dir=work_dir, 
-                                     inputs=[graph_filename],
-                                     outfile=to_index_file)
+            # Retain only the specified paths (only one should really exist)
+            command = ['vg', 'mod', '-N'] + ref_options + ['-t', str(job.cores), os.path.basename(graph_filename)]
+            options.drunner.call(command, work_dir=work_dir, 
+                                 inputs=[graph_filename],
+                                 outfile=to_index_file)
                 
-        time.sleep(1)
+    time.sleep(1)
 
-        # Now we have the combined to-index graph in one vg file. We'll load
-        # it (which deduplicates nodes/edges) and then find kmers.
-        RealTimeLogger.get().info("Finding kmers in {} to {}".format(
-            to_index_filename, kmers_filename))
+    # Now we have the combined to-index graph in one vg file. We'll load
+    # it (which deduplicates nodes/edges) and then find kmers.
+    RealTimeLogger.get().info("Finding kmers in {} to {}".format(
+        to_index_filename, kmers_filename))
 
-        # Make the GCSA2 kmers file
-        with open(kmers_filename, "w") as kmers_file:
-            command = ['vg', 'kmers',  os.path.basename(to_index_filename), '-g', '-B', '-k',
-                       str(options.kmer_size), '-H', '1000000000', '-T', '1000000001', '-t', str(job.cores)]
-            options.drunner.call(command, work_dir=work_dir,
-                                 outfile=kmers_file)
+    # Make the GCSA2 kmers file
+    with open(kmers_filename, "w") as kmers_file:
+        command = ['vg', 'kmers',  os.path.basename(to_index_filename), '-g', '-B', '-k',
+                   str(options.kmer_size), '-H', '1000000000', '-T', '1000000001', '-t', str(job.cores)]
+        options.drunner.call(command, work_dir=work_dir,
+                             outfile=kmers_file)
 
-        time.sleep(1)
+    time.sleep(1)
 
-        # Where do we put the GCSA2 index?
-        gcsa_filename = graph_filename + ".gcsa"
+    # Where do we put the GCSA2 index?
+    gcsa_filename = graph_filename + ".gcsa"
 
-        RealTimeLogger.get().info("GCSA-indexing {} to {}".format(
-                kmers_filename, gcsa_filename))
+    RealTimeLogger.get().info("GCSA-indexing {} to {}".format(
+            kmers_filename, gcsa_filename))
 
-        # Make the gcsa2 index. Make sure to use 3 doubling steps to work
-        # around <https://github.com/vgteam/vg/issues/301>
-        command = ['vg', 'index', '-t', str(job.cores), '-i', 
-            os.path.basename(kmers_filename), '-g', os.path.basename(gcsa_filename),
-            '-X', '3', '-Z', '2000']
-        options.drunner.call(command, work_dir=work_dir)
+    # Make the gcsa2 index. Make sure to use 3 doubling steps to work
+    # around <https://github.com/vgteam/vg/issues/301>
+    command = ['vg', 'index', '-t', str(job.cores), '-i', 
+        os.path.basename(kmers_filename), '-g', os.path.basename(gcsa_filename),
+        '-X', '3', '-Z', '2000']
+    options.drunner.call(command, work_dir=work_dir)
 
-        # Where do we put the XG index?
-        xg_filename = graph_filename + ".xg"
+    # Checkpoint index to output store
+    if not options.force_outstore or options.tool == 'index':
+        write_to_store(job, options, os.path.join(work_dir, gcsa_filename), use_out_store = True)
+        write_to_store(job, options, os.path.join(work_dir, gcsa_filename) + ".lcp", use_out_store = True)
 
-        RealTimeLogger.get().info("XG-indexing {} to {}".format(
-                graph_filename, xg_filename))
-        
-        command = ['vg', 'index', '-t', str(job.cores), '-x', 
-            os.path.basename(xg_filename), os.path.basename(graph_filename)]
-        options.drunner.call(command, work_dir=work_dir)
+    # Not in standalone Mode, then we write it to the file store
+    if options.tool != 'index':
+        gcsa_file_id = write_to_store(job, options, os.path.join(work_dir, gcsa_filename))
+        lcp_file_id = write_to_store(job, options, os.path.join(work_dir, gcsa_filename) + ".lcp")
+        return gcsa_file_id, lcp_file_id
 
-    else:
-        raise RuntimeError("Invalid indexing mode: " + options.index_mode)
 
-    # Define a file to keep the compressed index in, so we can send it to
-    # the output store.
-    index_dir_tgz = "{}/index.tar.gz".format(
-        job.fileStore.getLocalTempDir())
+def run_xg_indexing(job, options, inputGraphFileID):
+    """ Make the xg index and return its store id
+    """
+    
+    RealTimeLogger.get().info("Starting xg indexing...")
+    
+    graph_name = os.path.basename(options.vg_graph)
 
-    # Now save the indexed graph directory to the file store. It can be
-    # cleaned up since only our children use it.
-    RealTimeLogger.get().info("Compressing index of {}".format(
-        graph_filename))
-    index_dir_id = write_global_directory(job.fileStore, graph_dir,
-        cleanup=True, tee=index_dir_tgz, compress=False)
+    # Define work directory for docker calls
+    work_dir = job.fileStore.getLocalTempDir()
 
-    # Save it as output
-    RealTimeLogger.get().info("Uploading index of {}".format(
-        graph_filename))
-    index_key = os.path.basename(index_dir_tgz)
-    out_store.write_output_file(index_dir_tgz, index_key)
-    RealTimeLogger.get().info("Index {} uploaded successfully".format(
-        index_key))
+    # Our local copy of the graph
+    graph_filename = os.path.join(work_dir, graph_name)
+    read_from_store(job, options, inputGraphFileID, graph_filename)    
 
-    return index_key, index_dir_id
+    # Where do we put the XG index?
+    xg_filename = graph_filename + ".xg"
 
-def run_only_indexing(job, options, inputGraphFileID):
-    """ run indexing logic by itself.  
+    # Now run the indexer.
+    RealTimeLogger.get().info("XG Indexing {}".format(options.vg_graph))            
+
+    command = ['vg', 'index', '-t', str(job.cores), '-x', 
+        os.path.basename(xg_filename), os.path.basename(graph_filename)]
+    options.drunner.call(command, work_dir=work_dir)
+
+    # Checkpoint index to output store
+    if not options.force_outstore or options.tool == 'index':
+        write_to_store(job, options, os.path.join(work_dir, xg_filename), use_out_store = True)
+
+    # Not in standalone Mode, then we write it to the file store
+    if options.tool != 'index':
+        xg_file_id = write_to_store(job, options, os.path.join(work_dir, xg_filename))
+        return xg_file_id
+    
+
+def run_indexing(job, options, inputGraphFileID):
+    """ run indexing logic by itself.  Return pair of idx for xg and gcsa output index files  
     """
 
-    index_key_and_id = job.addChildJobFn(run_indexing, options, inputGraphFileID, cores=options.index_cores, memory="4G", disk="2G").rv()
+    gcsa_and_lcp_ids = job.addChildJobFn(run_gcsa_indexing, options, inputGraphFileID,
+                                      cores=options.index_cores, memory="4G", disk="2G").rv()
+    xg_index_id = job.addChildJobFn(run_xg_indexing, options, inputGraphFileID,
+                                      cores=options.index_cores, memory="4G", disk="2G").rv()
 
-    return index_key_and_id
+    return xg_index_id, gcsa_and_lcp_ids
 
 
 def main():
@@ -265,6 +255,10 @@ def main():
     # make the docker runner
     options.drunner = DockerRunner(
         docker_tool_map = get_docker_tool_map(options))
+
+    # Some file io is dependent on knowing if we're in the pipeline
+    # or standalone. Hack this in here for now
+    options.tool = 'index'
     
     # How long did it take to run the entire pipeline, in seconds?
     run_time_pipeline = None
@@ -276,10 +270,10 @@ def main():
         if not toil.options.restart:
             
             # Upload local files to the remote IO Store
-            inputGraphFileID = toil.importFile(clean_toil_path(options.vg_graph))
+            inputGraphFileID = import_to_store(toil, options, options.vg_graph)
             
             # Make a root job
-            root_job = Job.wrapJobFn(run_only_indexing, options, inputGraphFileID,
+            root_job = Job.wrapJobFn(run_indexing, options, inputGraphFileID,
                                      cores=2, memory="5G", disk="2G")
             
             # Run the job and store the returned list of output files to download


### PR DESCRIPTION
Get rid of index.tar.gz which was used to pass the graph and all indexes from job to job, and was often downloaded and untared when only one (or zero!) of the files it contains was needed. 