### PR TITLE
Reactivate tests

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -70,7 +70,6 @@ class VGCGLTest(TestCase):
 
         self._assertOutput('NA12877_17.vcf', self.local_outstore)
 
-    @skip("Skipping lrc_kir test")
     def test_chr19_sampleNA12877(self):
         ''' Test sample LRC KIR output
         '''
@@ -84,23 +83,21 @@ class VGCGLTest(TestCase):
         self.test_xg_index = os.path.join(self.workdir, 'LRC_KIR_chrom_name_chop_100.small.vg.xg')
         self.test_gcsa_index = os.path.join(self.workdir, 'LRC_KIR_chrom_name_chop_100.small.vg.gcsa')
         
-        self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
-                  self.outstore,  '--gcsa_index', self.test_gcsa_index,
+        self._run(self.base_command, self.jobStoreLocal, self.test_vg_graph, self.sample_reads, 'NA12877',
+                  self.local_outstore,  '--gcsa_index', self.test_gcsa_index,
                   '--xg_index', self.test_xg_index, '--path_name', '19', '--path_size', '50000')
-        self._assertOutput('NA12877_19.vcf', self.outstore)
+        self._assertOutput('NA12877_19.vcf', self.local_outstore)
 
-    @skip("Skipping MHC test")
     def test_chr6_MHC_sampleNA12877(self):
         ''' Test sample MHC output
         '''
         self.sample_reads = 's3://cgl-pipeline-inputs/vg_cgl/ci/NA12877.mhc.bam.small.fq'
         self.test_vg_graph = 's3://cgl-pipeline-inputs/vg_cgl/ci/MHC_chrom_name_chop_100.small.vg'
         self.test_gcsa_index = 's3://cgl-pipeline-inputs/vg_cgl/ci/MHC_chrom_name_chop_100.small.vg.gcsa'
-        self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
-                                   self.outstore,  '--gcsa_index', self.test_gcsa_index, '--path_name', '6', '--path_size', '50000')
-        self._assertOutput('NA12877_6.vcf', self.outstore)
+        self._run(self.base_command, self.jobStoreLocal, self.test_vg_graph, self.sample_reads, 'NA12877',
+                                   self.local_outstore,  '--gcsa_index', self.test_gcsa_index, '--path_name', '6', '--path_size', '50000')
+        self._assertOutput('NA12877_6.vcf', self.local_outstore)
 
-    @skip("Skipping SMA test")
     def test_chr5_SMA_sampleNA12877(self):
         ''' Test sample SMA output
         '''
@@ -108,9 +105,9 @@ class VGCGLTest(TestCase):
         subprocess.check_call(['aws', 's3', 'cp', 's3://cgl-pipeline-inputs/vg_cgl/ci/SMA_chrom_name_chop_100.small.vg', self.workdir])
         self.sample_reads = os.path.join(self.workdir, 'NA12877.sma.bam.small.fq')
         self.test_vg_graph = os.path.join(self.workdir, 'SMA_chrom_name_chop_100.small.vg')
-        self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
-                                   self.outstore, '--path_name', '5', '--path_size', '50000')
-        self._assertOutput('NA12877_5.vcf', self.outstore)
+        self._run(self.base_command, self.jobStoreLocal, self.test_vg_graph, self.sample_reads, 'NA12877',
+                                   self.local_outstore, '--path_name', '5', '--path_size', '50000')
+        self._assertOutput('NA12877_5.vcf', self.local_outstore)
     
     def _run(self, *args):
         args = list(concat(*args))

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -503,6 +503,9 @@ def main():
     # Some file io is dependent on knowing if we're in the pipeline
     # or standalone. Hack this in here for now
     options.tool = 'call'
+
+    # Throw error if something wrong with IOStore string
+    IOStore.get(options.out_store)
         
     # How long did it take to run the entire pipeline, in seconds?
     run_time_pipeline = None

--- a/src/toil_vg/vg_evaluation_pipeline.py
+++ b/src/toil_vg/vg_evaluation_pipeline.py
@@ -258,6 +258,9 @@ def main():
     # or standalone. Hack this in here for now
     options.tool = 'pipeline'
 
+    # Throw error if something wrong with IOStore string
+    IOStore.get(options.out_store)
+
     # How long did it take to run the entire pipeline, in seconds?
     run_time_pipeline = None
         

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -259,6 +259,9 @@ def main():
     # Some file io is dependent on knowing if we're in the pipeline
     # or standalone. Hack this in here for now
     options.tool = 'index'
+
+    # Throw error if something wrong with IOStore string
+    IOStore.get(options.out_store)
     
     # How long did it take to run the entire pipeline, in seconds?
     run_time_pipeline = None

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -312,6 +312,9 @@ def main():
     # Some file io is dependent on knowing if we're in the pipeline
     # or standalone. Hack this in here for now
     options.tool = 'map'
+
+    # Throw error if something wrong with IOStore string
+    IOStore.get(options.out_store)
     
     # How long did it take to run the entire pipeline, in seconds?
     run_time_pipeline = None


### PR DESCRIPTION
Switched to local stores for everything because the uuid() business (was it ever tested?) seems to cause errors writing to the output store (not to mention potential issues with trailing buckets).  
* don't really know why
* s3 stores work on command line
* can't reproduce with random strings entered for store (instead of uuid4()).  weird. 
* focus of the tests is not toil / IOstore's S3 functionality so running locally is fine by me for now