### PR TITLE
Switch vg docker to current master

### DIFF
--- a/config-toil-vg.tsv
+++ b/config-toil-vg.tsv
@@ -24,7 +24,7 @@ no-docker: False
 ##   Each tool is specified as a list where the first element is the docker image URL,
 ##   and the second element indicates if the docker image has an entrypoint or not
 # Optional: Dockerfile to use for vg
-vg-docker: ['quay.io/glennhickey/vg:latest', True]
+vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1951-g94f14be', True]
 
 # Optional: Dockerfile to use for bcftools
 bcftools-docker: ['quay.io/cmarkello/bcftools', False]

--- a/src/toil_vg/vg_evaluation_pipeline.py
+++ b/src/toil_vg/vg_evaluation_pipeline.py
@@ -262,7 +262,7 @@ def generate_config():
         ##   Each tool is specified as a list where the first element is the docker image URL,
         ##   and the second element indicates if the docker image has an entrypoint or not
         # Optional: Dockerfile to use for vg
-        vg-docker: ['quay.io/glennhickey/vg:latest', True]
+        vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1951-g94f14be', True]
 
         # Optional: Dockerfile to use for bcftools
         bcftools-docker: ['quay.io/cmarkello/bcftools', False]


### PR DESCRIPTION
I have updated normal_NA12877_*.vcf.gz* and the config file in the CI s3 bucket to coincide with the output of this latest version.  

Normal files for previous version in normal.v1.4.0-1725-gce49cd4.tar.gz