### PR TITLE
Use vg chunk for all chunking

### DIFF
--- a/config-toil-vg.tsv
+++ b/config-toil-vg.tsv
@@ -27,7 +27,7 @@ no-docker: False
 ##   of through docker
 # Optional: Dockerfile to use for vg
 
-vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1976-g828f17e', True]
+vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1980-g38453bf', True]
 
 # Optional: Dockerfile to use for bcftools
 bcftools-docker: ['quay.io/cmarkello/bcftools', False]

--- a/config-toil-vg.tsv
+++ b/config-toil-vg.tsv
@@ -23,6 +23,8 @@ no-docker: False
 ## Docker Tool List ##
 ##   Each tool is specified as a list where the first element is the docker image URL,
 ##   and the second element indicates if the docker image has an entrypoint or not
+##   If left blank, then the tool will be run directly from the command line instead
+##   of through docker
 # Optional: Dockerfile to use for vg
 
 vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1976-g828f17e', True]
@@ -73,6 +75,14 @@ num-fastq-chunks: 3
 # Optional: Number of threads during the alignment step
 alignment-cores: 3
 
+# Optional: Number of threads to use for Rocksdb GAM indexing
+# Generally, this should be kept low as speedup drops off radically 
+# after a few threads.
+gam-index-cores: 3
+
+# Optional: Context expansion used for gam chunking
+chunk_context: 20
+
 # Optional: Core arguments for vg mapping
 vg-map-args: ['-i', '-M2', '-W', '500', '-u', '0', '-U', '-O', '-S', '50', '-a']
 
@@ -84,6 +94,7 @@ alignment-disk: '2G'
 
 # Optional: Type of vg index to use for mapping (either 'gcsa-kmer' or 'gcsa-mem')
 index-mode: gcsa-mem
+
 
 #########################
 ### vg_call Arguments ###

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -53,17 +53,17 @@ class VGCGLTest(TestCase):
         self.connection = S3Connection()
         self.bucket = self.connection.get_bucket('cgl-pipeline-inputs')
         self._download_input('config-toil-vg.tsv', self.configFile)
-        
+                
         self.base_command = concat('toil-vg', 'run', '--config', self.configFile,
                                    '--realTimeLogging', '--logInfo', '--edge_max', '5', '--kmer_size',
-                                   '16', '--num_fastq_chunks', '4', '--call_chunk_size', '20000', '--overwrite',
+                                   '16', '--num_fastq_chunks', '4', '--call_chunk_size', '20000',
                                    '--index_mode', 'gcsa-mem', '--include_primary', '--index_cores', '8', '--alignment_cores', '8',
                                    '--calling_cores', '8')
         
         # default output store
         self.outstore = 'aws:us-west-2:toilvg-jenkinstest-outstore-{}'.format(uuid4())
         self.local_outstore = os.path.join(self.workdir, 'toilvg-jenkinstest-outstore-{}'.format(uuid4()))
-
+                
         # copy the sequence information for vcf comparison
         # (lumped in one file out of laziness.  todo: at least split by chromosome)
         self.chrom_fa = os.path.join(self.workdir, 'chrom.fa.gz')

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python2.7
 """
 Generate a VCF from a GAM and XG by splitting into GAM/VG chunks.
-Chunks are then called in series, and the VCFs stitched together.
-Any step whose expected output exists is skipped unles --overwrite 
-specified.  
-
-old docker vg tool= quay.io/ucsc_cgl/vg:1.4.0--4cbd3aa6d2c0449730975517fc542775f74910f3
-latest docker vg tool=quay.io/ucsc_cgl/vg:latest
 """
 from __future__ import print_function
 import argparse, sys, os, os.path, random, subprocess, shutil, itertools, glob
@@ -66,8 +60,6 @@ def chunked_call_parse_args(parser):
                         help="options to pass to vg genotype. wrap in \"\"")
     parser.add_argument("--calling_cores", type=int,
                         help="number of threads during the variant calling step")
-    parser.add_argument("--overwrite", action="store_true",
-                        help="always overwrite existing files")        
         
 def merge_call_opts(contig, offset, length, call_opts, sample_name, sample_flag = '-S'):
     """ combine input vg call  options with generated options, by adding user offset
@@ -100,147 +92,6 @@ def merge_call_opts(contig, offset, length, call_opts, sample_name, sample_flag 
         opts += " -l {}".format(length)
     return opts
 
-def make_chunks(path_name, path_size, chunk_size, overlap):
-    """ compute chunks as BED (0-based) 3-tuples: ie
-    (chr1, 0, 10) is the range from 0-9 inclusive of chr1
-    """
-    assert chunk_size > overlap
-    covered = 0
-    chunks = []
-    while covered < path_size:
-        start = max(0, covered - overlap)
-        end = min(path_size, start + chunk_size)
-        chunks.append((path_name, start, end))
-        covered = end
-    return chunks
-
-def chunk_base_name(path_name, out_dir, chunk_i = None, tag= ""):
-    """ centralize naming of output chunk-related files """
-    bn = os.path.join(out_dir, "{}-chunk".format(path_name))
-    if chunk_i is not None:
-        bn += "-{}".format(chunk_i)
-    return "{}{}".format(bn, tag)
-
-def chunk_gam(drunner, gam_path, xg_path, path_name, out_dir, chunks, filter_opts, overwrite):
-    """ use vg filter to chunk up the gam """
-    RealTimeLogger.get().info("Starting chunk_gam")
-    # make bed chunks
-    chunk_path = os.path.join(out_dir, path_name + "_chunks.bed")
-    with open(chunk_path, "w") as f:
-        for chunk in chunks:
-            f.write("{}\t{}\t{}\n".format(chunk[0], chunk[1], chunk[2]))
-    # run vg filter on the gam
-    stdout = ''
-    if overwrite or not any(
-            os.path.isfile(chunk_base_name(path_name, out_dir, i, ".gam")) \
-               for i in range(len(chunks))):
-        
-        out_file = os.path.join(out_dir, path_name + "-chunk")
-        command = [['vg', 'filter', os.path.basename(gam_path), '-x', os.path.basename(xg_path), '-R', os.path.basename(chunk_path), '-B', os.path.basename(out_file)] + filter_opts]
-        drunner.call(command, work_dir=out_dir)
-    
-def xg_path_node_id(drunner, xg_path, path_name, offset, out_dir):
-    """ use vg find to get the node containing a given path position """
-    #NOTE: vg find -p range offsets are 0-based inclusive.  
-    tmp_out_filename = "{}/tmp_out_{}".format(out_dir, uuid4())
-    with open(tmp_out_filename, "w") as tmp_out_file:
-        command = [['vg', 'find', '-x', os.path.basename(xg_path), '-p',
-                   '{}:{}-{}'.format(str(path_name), str(offset), str(offset))]]
-        command.append(['vg', 'mod', '-o', '-'])
-        command.append(['vg', 'view', '-j', '-'])
-        drunner.call(command, work_dir=out_dir, outfile=tmp_out_file)
-
-    command = [['jq', '.node[0].id', os.path.basename(tmp_out_filename)]]
-
-    # todo : fix this hack:
-    # why do we need to do this here? Is it something to do with the jq
-    # docker image? all the other tools seem to check /data/ transparently
-    if 'jq' in drunner.docker_tool_map:
-        command[0][2] = os.path.join('/data', command[0][2])
-        
-    stdout = drunner.call(command, work_dir=out_dir, check_output=True, outfile=None)
-    
-    return int(stdout)
-
-def xg_path_predecessors(drunner, xg_path, path_name, node_id, out_dir, context = 1):
-    """ get nodes before given node in a path. """
-    
-    stdout = ''
-    command = [['vg', 'find', '-x', os.path.basename(xg_path), '-n', str(node_id), '-c', str(context)]]
-    command.append(['vg', 'view', '-j', '-'])
-    stdout = drunner.call(command, work_dir=out_dir, check_output=True)
-    
-    # get our json graph
-    j = json.loads(stdout)
-    paths = j["path"]
-    path = [x for x in paths if x["name"] == path_name][0]
-    mappings = path["mapping"]
-    assert len(mappings) > 0
-    # check that we have a node_mapping
-    assert len([x for x in mappings if x["position"]["node_id"] == node_id]) == 1
-    # collect mappings that come before
-    out_ids = []
-    for mapping in mappings:
-        if mapping["position"]["node_id"] == node_id:
-            break
-        out_ids.append(mapping["position"]["node_id"])
-    return out_ids
-
-def chunk_vg(drunner, xg_path, path_name, out_dir, chunks, chunk_i, overwrite):
-    """ use vg find to make one chunk of the graph """
-    chunk = chunks[chunk_i]
-    vg_chunk_path = chunk_base_name(chunk[0], out_dir, chunk_i, ".vg")
-    if overwrite or not os.path.isfile(vg_chunk_path):
-        first_node = xg_path_node_id(drunner, xg_path, chunk[0], int(chunk[1]), out_dir)
-        # xg_path query takes 0-based inclusive coordinates, so we
-        # subtract 1 below to convert from BED chunk (0-based exlcusive)
-        last_node = xg_path_node_id(drunner, xg_path, chunk[0], chunk[2] - 1, out_dir)
-        assert first_node > 0 and last_node >= first_node
-        # todo: would be cleaner to not have to pad context here
-        
-        with open(vg_chunk_path, "w") as vg_chunk_path_stream:
-            command = [['vg', 'find', '-x', os.path.basename(xg_path), '-r', str(first_node)+':'+str(last_node), '-c', '1']]
-            drunner.call(command, work_dir=out_dir, outfile=vg_chunk_path_stream)
-            RealTimeLogger.get().info("Output vg chunk size {}".format(
-                os.path.getsize(vg_chunk_path)))
-        
-        # but because we got a context, manually go in and make sure
-        # our path starts at first_node by deleting everything before
-        left_path_padding = xg_path_predecessors(drunner, xg_path, path_name, first_node,
-                                                 out_dir, context = 1)
-        for destroy_id in left_path_padding:
-            # destroy should take node list
-            destroy_list = vg_chunk_path + ".destroy"
-
-            with open(destroy_list, "w") as destroy_list_stream:
-                command = [['vg', 'mod', '-y', str(destroy_id), os.path.basename(vg_chunk_path)]]
-                command.append(['vg', 'mod', '-o', '-'])
-                drunner.call(command, work_dir=out_dir, outfile=destroy_list_stream)
-            
-            drunner.call(['mv', vg_chunk_path + ".destroy", vg_chunk_path])
-          
-def xg_path_node_offset(drunner, xg_path, path_name, offset, out_dir):
-    """ get the offset of the node containing the given position of a path
-    """
-    # first we find the node
-    node_id = xg_path_node_id(drunner, xg_path, path_name, offset, out_dir)
-
-    # now we find the offset of the beginning of the node
-    command = [['vg', 'find', '-x', os.path.basename(xg_path), '-P', str(path_name), '-n', str(node_id)]]
-    stdout = drunner.call(command, work_dir=out_dir, check_output=True) 
-   
-    toks = stdout.split()
-    # if len > 2 then we have a cyclic path, which we're assuming we don't
-    assert len(toks) == 2
-    assert toks[0] == str(node_id)
-    node_offset = int(toks[1])
-    # node_offset must be before
-    assert node_offset <= offset
-    # sanity check (should really use node size instead of 1000 here)
-    assert offset - node_offset < 1000
-
-    return node_offset
-    
 def sort_vcf(drunner, vcf_path, sorted_vcf_path):
     """ from vcflib """
     vcf_dir, vcf_name = os.path.split(vcf_path)
@@ -252,122 +103,114 @@ def sort_vcf(drunner, vcf_path, sorted_vcf_path):
                       ['sort', '-k1,1d', '-k2,2n']], outfile=outfile,
                      work_dir=vcf_dir)
 
-def run_vg_call(options, xg_path, vg_path, gam_path, path_name, chunk, chunk_i, path_size, 
-                pileup_opts, call_options, sample_name, work_dir, out_dir, vcf_path,
-                threads, overwrite):
+def run_vg_call(options, xg_path, vg_path, gam_path, path_name, chunk_offset, path_size, work_dir, vcf_path):
     """ Create a VCF with vg call """
                         
     # do the pileup.  this is the most resource intensive step,
     # especially in terms of mermory used.
-    pu_path = chunk_base_name(path_name, out_dir, chunk_i, ".pu")
-    if overwrite or not os.path.isfile(pu_path):
-        with open(pu_path, "w") as pu_path_stream:
-            command = [['vg', 'pileup', os.path.basename(vg_path), os.path.basename(gam_path), '-t', str(threads)] + pileup_opts]
-            options.drunner.call(command, work_dir=out_dir, outfile=pu_path_stream)
+    # can stream pileup directly to caller. would save disk but worry about memory. 
+    pu_path = os.path.join(work_dir, 'chunk_{}_{}.pu'.format(path_name, chunk_offset))
+    with open(pu_path, "w") as pu_path_stream:
+        command = [['vg', 'filter', os.path.basename(gam_path),
+                    '-x', os.path.basename(xg_path), '-t', '1'] + options.filter_opts]
+        command.append(['vg', 'pileup', os.path.basename(vg_path), '-',
+                        '-t', str(options.calling_cores)] + options.pileup_opts)
+        options.drunner.call(command, work_dir=work_dir, outfile=pu_path_stream)
 
     # do the calling.
-    # requires the latest version of vg as of 8/2/2016
-    if overwrite or not os.path.isfile(vcf_path + ".gz"):
-        offset = xg_path_node_offset(options.drunner, xg_path, chunk[0], chunk[1], out_dir)
-        merged_call_opts = merge_call_opts(chunk[0], offset, path_size,
-                                           call_options, sample_name)
-        with open(vcf_path + ".us", "w") as vgcall_stdout, open(vcf_path + ".call_log", "w") as vgcall_stderr:
-            command=[['vg', 'call', os.path.basename(vg_path), os.path.basename(pu_path), '-t',
-                     str(threads)] + str(merged_call_opts).split()]
-            options.drunner.call(command, work_dir=out_dir,
-                        outfile=vgcall_stdout, errfile=vgcall_stderr)
+    merged_call_opts = merge_call_opts(path_name, chunk_offset, path_size,
+                                       options.call_opts, options.sample_name)
+    with open(vcf_path + ".us", "w") as vgcall_stdout, open(vcf_path + ".call_log", "w") as vgcall_stderr:
+        command = [['vg', 'call', os.path.basename(vg_path), os.path.basename(pu_path), '-t',
+                 str(options.calling_cores)] + str(merged_call_opts).split()]
+        options.drunner.call(command, work_dir=work_dir,
+                             outfile=vgcall_stdout, errfile=vgcall_stderr)
  
                 
-def run_vg_genotype(options, xg_path, vg_path, gam_path, path_name, chunk, chunk_i, path_size, 
-                    genotype_options, sample_name, work_dir, out_dir, vcf_path,
-                    threads, overwrite):
+def run_vg_genotype(options, xg_path, vg_path, gam_path, path_name, chunk_offset, path_size, work_dir, vcf_path):
+                    
     """ Create a VCF with vg genotype """
 
+    # Filter the gam
+    # Todo: can we stream directly to indexer?
+    filter_gam_path = os.path.join(work_dir, os.path.basename(gam_path) + ".filter")
+    with open(filter_gam_path, 'w') as filter_stdout:
+        command = ['vg', 'filter', os.path.basename(gam_path), '-t', str(options.calling_cores),
+                   '-x', os.path.basename(xg_path)] + options.filter_opts
+        options.drunner.call(command, work_dir=work_dir, outfile=filter_stdout)
+               
     # Make a gam index
-    gam_index_path = os.path.join(out_dir, os.path.basename(gam_path) + ".index")
-    if overwrite or not os.path.isfile(gam_index_path):
-        command = ['vg', 'index', '-N', os.path.basename(gam_path), '-d', os.path.basename(gam_index_path)]
-        options.drunner.call(command, work_dir=work_dir)
+    gam_index_path = os.path.join(work_dir, os.path.basename(filter_gam_path) + ".index")
+    command = ['vg', 'index', '-N', os.path.basename(filter_gam_path), '-d', os.path.basename(gam_index_path)]
+    options.drunner.call(command, work_dir=work_dir)
 
     # Do the genotyping
-    if overwrite or not os.path.isfile(vcf_path + ".gz"):
-        offset = xg_path_node_offset(options.drunner, xg_path, chunk[0], chunk[1], out_dir)
-        merged_genotype_opts = merge_call_opts(chunk[0], offset, path_size,
-                                           genotype_options, sample_name, sample_flag = '-s')
-        with open(vcf_path + ".us", "w") as vgcall_stdout, open(vcf_path + ".call_log", "w") as vgcall_stderr:
+    merged_genotype_opts = merge_call_opts(path_name, chunk_offset, path_size,
+                                           options.genotype_options, sample_name, sample_flag = '-s')
+    with open(vcf_path + ".us", "w") as vgcall_stdout, open(vcf_path + ".call_log", "w") as vgcall_stderr:
 
-            command=[['vg', 'genotype', os.path.basename(vg_path), os.path.basename(gam_index_path),
-                      '-t', str(threads), '-v'] + str(merged_genotype_opts).split()]
-            options.drunner.call(command, work_dir=out_dir,
-                        outfile=vgcall_stdout, errfile=vgcall_stderr)
+        command=[['vg', 'genotype', os.path.basename(vg_path), os.path.basename(gam_index_path),
+                  '-t', str(options.calling_cores), '-v'] + str(merged_genotype_opts).split()]
+        options.drunner.call(command, work_dir=work_dir,
+                             outfile=vgcall_stdout, errfile=vgcall_stderr)
 
-def call_chunk(job, options, xg_file_id, path_name, chunks, chunk_i,
-               vg_chunk_file_id, gam_chunk_file_id, path_size, overlap,
-               pileup_opts, call_options, genotype_options, sample_name, threads, overwrite):
+def call_chunk(job, options, path_name, chunk_i, num_chunks, chunk_offset, clipped_chunk_offset,
+               vg_chunk_file_id, gam_chunk_file_id, path_size):
+    """ create VCF from a given chunk """
    
     RealTimeLogger.get().info("Running call_chunk on path {} and chunk {}".format(path_name, chunk_i))
     
-    # Set up the IO stores each time, since we can't unpickle them on Azure for
-    # some reason.
-    RealTimeLogger.get().info("Attempting to set up the IO stores.")
-    out_store = IOStore.get(options.out_store)
-
     # Define work directory for docker calls
     work_dir = job.fileStore.getLocalTempDir()
 
-    # Download xg
-    xg_path = os.path.join(work_dir, 'graph.vg.xg')
-    read_from_store(job, options, xg_file_id, xg_path)
-    
-    """ create VCF from a given chunk """
-    out_dir = work_dir
-    chunk = chunks[chunk_i]
-    path_name = chunk[0]
-    vg_path = chunk_base_name(path_name, out_dir, chunk_i, ".vg")
-    gam_path = chunk_base_name(path_name, out_dir, chunk_i, ".gam")
-
-    # Download the chunked vg and gam files
-    RealTimeLogger.get().info("Attempting to read vg_path and gam_path files.")
+    # Read our gam files from the store
+    vg_path = os.path.join(work_dir, 'chunk_{}_{}.vg'.format(path_name, chunk_offset))
+    gam_path = os.path.join(work_dir, 'chunk_{}_{}.gam'.format(path_name, chunk_offset))
     read_from_store(job, options, vg_chunk_file_id, vg_path)
     read_from_store(job, options, gam_chunk_file_id, gam_path)
 
-    vcf_path = chunk_base_name(path_name, out_dir, chunk_i, ".vcf")
-    
+    # output vcf path
+    vcf_path = os.path.join(work_dir, 'chunk_{}_{}.vcf'.format(path_name, chunk_offset))
+
+    # get the xg index, required for vg filter -D.
+    # todo? can we avoid this somehow?  is it better to copy in a big xg than regenerate?
+    xg_path = os.path.join(work_dir, 'chunk_{}_{}.xg'.format(path_name, chunk_offset))
+    options.drunner.call(['vg', 'index', os.path.basename(vg_path), '-x',
+                          os.path.basename(xg_path), '-t', str(options.calling_cores)],
+                         work_dir = work_dir)
     # Run vg call
     if options.genotype:
-        run_vg_genotype(options, xg_path, vg_path, gam_path, path_name, chunk, chunk_i, path_size, 
-                        genotype_options, sample_name, work_dir, out_dir,
-                        vcf_path, threads, overwrite)
+        run_vg_genotype(options, xg_path, vg_path, gam_path, path_name, chunk_offset,
+                        path_size, work_dir, vcf_path)
     else:
-        run_vg_call(options, xg_path, vg_path, gam_path, path_name, chunk, chunk_i, path_size, 
-                    pileup_opts, call_options, sample_name, work_dir, out_dir,
-                    vcf_path, threads, overwrite)
+        run_vg_call(options, xg_path, vg_path, gam_path, path_name, chunk_offset,
+                    path_size, work_dir, vcf_path)
 
     # Sort the output
     sort_vcf(options.drunner, vcf_path + ".us", vcf_path)
     options.drunner.call(['rm', vcf_path + '.us'])
     command=['bgzip', '{}'.format(os.path.basename(vcf_path))]
-    options.drunner.call(command, work_dir=out_dir)
+    options.drunner.call(command, work_dir=work_dir)
     command=['tabix', '-f', '-p', 'vcf', '{}'.format(os.path.basename(vcf_path+".gz"))]
-    options.drunner.call(command, work_dir=out_dir)
+    options.drunner.call(command, work_dir=work_dir)
     
     # do the vcf clip
-    left_clip = 0 if chunk_i == 0 else overlap / 2
-    right_clip = 0 if chunk_i == len(chunks) - 1 else overlap / 2
-    clip_path = chunk_base_name(path_name, out_dir, chunk_i, "_clip.vcf")
-    if overwrite or not os.path.isfile(clip_path):
-        with open(clip_path, "w") as clip_path_stream:
-            # passing in offset this way pretty hacky, should have its own option
-            call_toks = call_options
-            offset = 0
-            if "-o" in call_toks:
-                offset = int(call_toks[call_toks.index("-o") + 1])
-            elif "--offset" in call_toks:
-                offset = int(call_toks[call_toks.index("--offset") + 1])
-            command=['bcftools', 'view', '-r', '{}:{}-{}'.format(
-                path_name, offset + chunk[1] + left_clip + 1,
-                offset + chunk[2] - right_clip), os.path.basename(vcf_path) + ".gz"]
-            options.drunner.call(command, work_dir=out_dir, outfile=clip_path_stream)
+    left_clip = 0 if chunk_i == 0 else options.overlap / 2
+    right_clip = 0 if chunk_i == num_chunks - 1 else options.overlap / 2
+    clip_path = os.path.join(work_dir, 'chunk_{}_{}_clip.vcf'.format(path_name, chunk_offset))
+    with open(clip_path, "w") as clip_path_stream:
+        # passing in offset this way pretty hacky, should have its own option
+        call_toks = options.call_opts
+        offset = 0
+        if "-o" in call_toks:
+            offset = int(call_toks[call_toks.index("-o") + 1])
+        elif "--offset" in call_toks:
+            offset = int(call_toks[call_toks.index("--offset") + 1])
+        command=['bcftools', 'view', '-r', '{}:{}-{}'.format(
+            path_name, offset + clipped_chunk_offset + left_clip + 1,
+            offset + clipped_chunk_offset + options.call_chunk_size - right_clip),
+                 os.path.basename(vcf_path) + ".gz"]
+        options.drunner.call(command, work_dir=work_dir, outfile=clip_path_stream)
 
     # save clip.vcf files to job store
     clip_file_id = write_to_store(job, options, clip_path)
@@ -377,108 +220,114 @@ def call_chunk(job, options, xg_file_id, path_name, chunks, chunk_i,
 def run_calling(job, options, xg_file_id, alignment_file_id, path_name, path_size):
     
     RealTimeLogger.get().info("Running variant calling on path {} from alignment file {}".format(path_name, str(alignment_file_id)))
-    
-    # Set up the IO stores each time, since we can't unpickle them on Azure for
-    # some reason.
-    out_store = IOStore.get(options.out_store)
-    
+        
     # Define work directory for docker calls
     work_dir = job.fileStore.getLocalTempDir()
 
-    # Download the input
+    # make sure call-opts and genotype-opts are in list format
+    # todo -- clean this out
+    if type(options.call_opts) == str:
+        options.call_opts = options.call_opts.split(" ")
+    if type(options.genotype_opts) == str:
+        options.genotype_opts = options.genotype_opts.split(" ")
+
+    # Download the input from the store
     xg_path = os.path.join(work_dir, 'graph.vg.xg')
     read_from_store(job, options, xg_file_id, xg_path)
     gam_path = os.path.join(work_dir, '{}.gam'.format(options.sample_name))
     read_from_store(job, options, alignment_file_id, gam_path)
-    
-    # How long did the calling take to run, in seconds?
-    run_time = None
 
-    assert options.overlap % 2 == 0
+    # Index the gam
+    gam_index_path = gam_path + '.index'
+    index_cmd = ['vg', 'index', '-N', gam_path, '-d', gam_index_path,
+                 '-t', str(options.gam_index_cores)]
+    options.drunner.call(index_cmd, work_dir=work_dir)
 
-    # compute overlapping chunks
-    chunks = make_chunks(path_name, path_size, options.call_chunk_size, options.overlap)
-    
-    # split the gam in one go
-    chunk_gam(options.drunner, gam_path, xg_path, path_name, work_dir,
-              chunks, options.filter_opts, options.overwrite)
+    # Chunk the graph and gam, using the xg and rocksdb indexes
+    output_bed_chunks_path = os.path.join(work_dir, 'output_bed_chunks_{}.bed'.format(path_name))
+    chunk_cmd = ['vg', 'chunk', '-x', os.path.basename(xg_path),
+                 '-a', os.path.basename(gam_index_path), '-c', str(options.chunk_context),
+                 '-p', path_name,
+                 '-g',
+                 '-s', str(options.call_chunk_size),
+                 '-o', str(options.overlap),
+                 '-b', 'call_chunk_{}'.format(path_name),
+                 '-t', str(options.calling_cores),
+                 '-R', os.path.basename(output_bed_chunks_path)]
+    options.drunner.call(chunk_cmd, work_dir=work_dir)
 
-    # call every chunk in series
+    # Scrape the BED into memory
+    bed_lines = []
+    with open(output_bed_chunks_path) as output_bed:
+        for line in output_bed:
+            toks = line.split('\t')
+            if len(toks) > 3:
+                bed_lines.append(toks)
+
+    # Go through the BED output of vg chunk, adding a child calling job for
+    # each chunk                
     clip_file_ids = []
-    for chunk_i, chunk in enumerate(chunks):
-        # make the graph chunk
-        chunk_vg(options.drunner, xg_path, path_name, work_dir, chunks, chunk_i, options.overwrite)
-        
-        vg_path = chunk_base_name(path_name, work_dir, chunk_i, ".vg")
-        gam_path = chunk_base_name(path_name, work_dir, chunk_i, ".gam")
-
-        # write chunks to job store
-        vg_chunk_file_id = write_to_store(job, options, vg_path)
-        gam_chunk_file_id = write_to_store(job, options, gam_path)
-        
-        # make sure call-opts and genotype-opts are in list format
-        if type(options.call_opts) == str:
-            options.call_opts = options.call_opts.split(" ")
-        if type(options.genotype_opts) == str:
-            options.genotype_opts = options.genotype_opts.split(" ")
-        clip_file_id = job.addChildJobFn(call_chunk, options, xg_file_id, path_name, chunks, chunk_i,
-                                         vg_chunk_file_id, gam_chunk_file_id,
-                                         path_size, options.overlap,
-                                         options.pileup_opts, options.call_opts, options.genotype_opts,
-                                         options.sample_name, options.calling_cores,
-                                         options.overwrite, cores=options.calling_cores,
+    for chunk_i, toks in enumerate(bed_lines):
+        assert toks[0] == path_name
+        chunk_bed_start = int(toks[1])
+        chunk_bed_end = int(toks[2])
+        chunk_bed_size = chunk_bed_end - chunk_bed_start
+        gam_chunk_path = os.path.join(work_dir, os.path.basename(toks[3].strip()))
+        assert os.path.splitext(gam_chunk_path)[1] == '.gam'
+        vg_chunk_path = os.path.splitext(gam_chunk_path)[0] + '.vg'
+        gam_chunk_file_id = write_to_store(job, options, gam_chunk_path)
+        vg_chunk_file_id = write_to_store(job, options, vg_chunk_path)
+        clipped_chunk_offset = chunk_i * options.call_chunk_size - chunk_i * options.overlap
+                
+        clip_file_id = job.addChildJobFn(call_chunk, options, path_name, chunk_i, len(bed_lines),
+                                         chunk_bed_start, clipped_chunk_offset,
+                                         vg_chunk_file_id, gam_chunk_file_id, path_size,
+                                         cores=options.calling_cores,
                                          memory=options.calling_mem, disk=options.calling_disk).rv()
         clip_file_ids.append(clip_file_id)
 
 
-    vcf_gz_tbi_file_id_pair = job.addFollowOnJobFn(merge_vcf_chunks, options, path_name, path_size, chunks, clip_file_ids, options.overwrite, cores=2, memory="4G", disk="2G").rv()
+    vcf_gz_tbi_file_id_pair = job.addFollowOnJobFn(merge_vcf_chunks, options, path_name, path_size,
+                                                   clip_file_ids, cores=2, memory="4G", disk="2G").rv()
  
     RealTimeLogger.get().info("Completed variant calling on path {} from alignment file {}".format(path_name, str(alignment_file_id)))
 
     return vcf_gz_tbi_file_id_pair
 
 
-def merge_vcf_chunks(job, options, path_name, path_size, chunks, clip_file_ids, overwrite):
+def merge_vcf_chunks(job, options, path_name, path_size, clip_file_ids):
     """ merge a bunch of clipped vcfs created above, taking care to 
     fix up the headers.  everything expected to be sorted already """
     
-    # Set up the IO stores each time, since we can't unpickle them on Azure for
-    # some reason.
-    out_store = IOStore.get(options.out_store)   
-
     # Define work directory for docker calls
-    out_dir = job.fileStore.getLocalTempDir()
+    work_dir = job.fileStore.getLocalTempDir()
     
-    vcf_path = os.path.join(out_dir, path_name + ".vcf")
+    vcf_path = os.path.join(work_dir, path_name + ".vcf")
     
-    if overwrite or not os.path.isfile(vcf_path):
-        first = True
-        for chunk_i, chunk in enumerate(chunks):
-            clip_path = chunk_base_name(path_name, out_dir, chunk_i, "_clip.vcf")
-            # Download clip.vcf file
-            read_from_store(job, options, clip_file_ids[chunk_i], clip_path)
+    for chunk_i, clip_file_id in enumerate(clip_file_ids):
+        
+        # Download clip.vcf file from the store
+        clip_path = os.path.join(work_dir, 'clip_{}.vcf'.format(chunk_i))
+        read_from_store(job, options, clip_file_id, clip_path)
 
-            if os.path.isfile(clip_path):
-                if first is True:
-                    # copy everything including the header
-                    with open(vcf_path, "w") as outfile:
-                        options.drunner.call(['cat', os.path.basename(clip_path)], outfile=outfile,
-                                             work_dir=out_dir)
-                    first = False
-                else:
-                    # add on everythin but header
-                    with open(vcf_path, "a") as outfile:
-                        options.drunner.call(['bcftools', 'view', '-H', os.path.basename(clip_path)],
-                                             outfile=outfile, work_dir=out_dir)
+        if chunk_i == 0:
+            # copy everything including the header
+            with open(vcf_path, "w") as outfile:
+                options.drunner.call(['cat', os.path.basename(clip_path)], outfile=outfile,
+                                     work_dir=work_dir)
+        else:
+            # add on everythin but header
+            with open(vcf_path, "a") as outfile:
+                options.drunner.call(['bcftools', 'view', '-H', os.path.basename(clip_path)],
+                                     outfile=outfile, work_dir=work_dir)
 
     # add a compressed indexed version
-    if overwrite or not os.path.isfile(vcf_path + ".gz"):
-        vcf_gz_file = vcf_path + ".gz"
-        with open(vcf_gz_file, "w") as vcf_gz_file_stream:
-            command=['bgzip', '-c', '{}'.format(os.path.basename(vcf_path))]
-            options.drunner.call(command, work_dir=out_dir, outfile=vcf_gz_file_stream)
-        command=['bcftools', 'tabix', '-f', '-p', 'vcf', '{}'.format(os.path.basename(vcf_path+".gz"))]
-        options.drunner.call(command, work_dir=out_dir)
+    vcf_gz_file = vcf_path + ".gz"
+    with open(vcf_gz_file, "w") as vcf_gz_file_stream:
+        command=['bgzip', '-c', '{}'.format(os.path.basename(vcf_path))]
+        options.drunner.call(command, work_dir=work_dir, outfile=vcf_gz_file_stream)
+    command=['bcftools', 'tabix', '-f', '-p', 'vcf', '{}'.format(os.path.basename(vcf_path+".gz"))]
+    options.drunner.call(command, work_dir=work_dir)
 
     # Save merged vcf files to the job store
     use_out_store = True if options.tool == 'call' else None

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -239,8 +239,8 @@ def run_calling(job, options, xg_file_id, alignment_file_id, path_name, path_siz
 
     # Index the gam
     gam_index_path = gam_path + '.index'
-    index_cmd = ['vg', 'index', '-N', gam_path, '-d', gam_index_path,
-                 '-t', str(options.gam_index_cores)]
+    index_cmd = ['vg', 'index', '-N', os.path.basename(gam_path), '-d',
+                 os.path.basename(gam_index_path), '-t', str(options.gam_index_cores)]
     options.drunner.call(index_cmd, work_dir=work_dir)
 
     # Chunk the graph and gam, using the xg and rocksdb indexes

--- a/src/toil_vg/vg_evaluation_pipeline.py
+++ b/src/toil_vg/vg_evaluation_pipeline.py
@@ -259,7 +259,7 @@ def generate_config():
         ##   of through docker
         # Optional: Dockerfile to use for vg
 
-        vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1976-g828f17e', True]
+        vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1980-g38453bf', True]
 
         # Optional: Dockerfile to use for bcftools
         bcftools-docker: ['quay.io/cmarkello/bcftools', False]

--- a/src/toil_vg/vg_evaluation_pipeline.py
+++ b/src/toil_vg/vg_evaluation_pipeline.py
@@ -458,6 +458,10 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    # Relative outstore paths can end up who-knows-where.  Make absolute.
+    if options.out_store[0] == '.':
+        options.out_store = os.path.abspath(options.out_store)
+
     if args.command == 'run':
         pipeline_main(options)
     elif args.command == 'index':

--- a/src/toil_vg/vg_evaluation_pipeline.py
+++ b/src/toil_vg/vg_evaluation_pipeline.py
@@ -172,22 +172,16 @@ def run_pipeline_map(job, options, graph_file_id, xg_file_id, gcsa_and_lcp_ids, 
 def run_pipeline_call(job, options, graph_file_id, xg_file_id, chr_gam_ids):
     """ Run variant calling on the chromosomes in parallel """
 
-    # index the gam keys
-    label_map = dict()
-    if len(chr_gam_ids) == 1 and chr_gam_ids[0][0] is None:
-        for chr_label in options.path_name:
-            label_map[chr_label] = chr_gam_ids[0][1]
-    else:
-        for chr_label, gam_id in chr_gam_ids:
-            label_map[chr_label] = gam_id
-    
-    # Run variant calling on .gams by chromosome if no path_name or path_size options are set 
     return_value = []
     vcf_tbi_file_id_pair_list = [] 
     if options.path_name and options.path_size:
+        assert len(chr_gam_ids) == len(options.path_name)
+        
         #Run variant calling
-        for chr_label, chr_length in itertools.izip(options.path_name, options.path_size):
-            alignment_file_id = label_map[chr_label]
+        for i in range(len(chr_gam_ids)):
+            alignment_file_id = chr_gam_ids[i]
+            chr_label = options.path_name[i]
+            chr_length = options.path_size[i]
             vcf_tbi_file_id_pair = job.addChildJobFn(run_calling, options, xg_file_id,
                                                      alignment_file_id, chr_label, chr_length,
                                                      cores=options.calling_cores, memory="4G", disk="2G").rv()
@@ -261,6 +255,8 @@ def generate_config():
         ## Docker Tool List ##
         ##   Each tool is specified as a list where the first element is the docker image URL,
         ##   and the second element indicates if the docker image has an entrypoint or not
+        ##   If left blank, then the tool will be run directly from the command line instead
+        ##   of through docker
         # Optional: Dockerfile to use for vg
 
         vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1976-g828f17e', True]
@@ -310,6 +306,14 @@ def generate_config():
         
         # Optional: Number of threads during the alignment step
         alignment-cores: 3
+
+        # Optional: Number of threads to use for Rocksdb GAM indexing
+        # Generally, this should be kept low as speedup drops off radically 
+        # after a few threads.
+        gam-index-cores: 3
+
+        # Optional: Context expansion used for gam chunking
+        chunk_context: 20
         
         # Optional: Core arguments for vg mapping
         vg-map-args: ['-i', '-M2', '-W', '500', '-u', '0', '-U', '-O', '-S', '50', '-a']
@@ -322,6 +326,7 @@ def generate_config():
 
         # Optional: Type of vg index to use for mapping (either 'gcsa-kmer' or 'gcsa-mem')
         index-mode: gcsa-mem
+
 
         #########################
         ### vg_call Arguments ###

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -250,7 +250,7 @@ def split_gam_into_chroms(work_dir, options, xg_file, gam_file):
                  '-P', os.path.basename(path_list_name),
                  '-b', os.path.splitext(os.path.basename(gam_file))[0],
                  '-t', str(options.alignment_cores),
-                 '-R', output_bed_name]
+                 '-R', os.path.basename(output_bed_name)]
     
     start_time = timeit.default_timer()
 


### PR DESCRIPTION
Replace vg filter and vg find with vg chunk for splitting gams and graphs, respecitively.  Advantages:
* does not require chunks to correspond to node id ranges
* more parallel
* fewer redundant loads of the whole-genome xg

