### PR TITLE
Add --interleaved command line option

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -77,7 +77,7 @@ class VGCGLTest(TestCase):
         self.sample_reads = os.path.join(self.workdir, 'NA12877.brca1.bam.fq')
         self.test_vg_graph = os.path.join(self.workdir, 'BRCA1_chrom_name_chop_100.vg')
         self._run(self.base_command, self.jobStoreLocal, self.test_vg_graph, self.sample_reads, 'NA12877',
-                  self.local_outstore, '--path_name', '17', '--call_opts', '--offset 43044293')
+                  self.local_outstore, '--path_name', '17', '--call_opts', '--offset 43044293', '--interleaved')
 
         self._assertOutput('NA12877_17.vcf', self.local_outstore)
     

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -108,8 +108,10 @@ def generate_config():
         # Optional: Context expansion used for gam chunking
         chunk_context: 20
         
-        # Optional: Core arguments for vg mapping
-        vg-map-args: ['-i', '-M2', '-W', '500', '-u', '0', '-U', '-O', '-S', '50', '-a']
+        # Core arguments for vg mapping
+        # Note -i/--interleaved will be ignored. use the --interleaved option 
+        # on the toil-vg command line instead
+        vg-map-args: ['-M2', '-W', '500', '-u', '0', '-U', '-O', '-S', '50', '-a']
         
         # Optional: Toil job memory allocation for mapping
         alignment-mem: '4G'

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -65,7 +65,10 @@ def map_parse_args(parser, stand_alone = False):
         help="number of threads during the alignment step")
     parser.add_argument("--index_mode", choices=["gcsa-kmer",
         "gcsa-mem"],
-        help="type of vg index to use for mapping")        
+        help="type of vg index to use for mapping")
+    parser.add_argument("--interleaved", action="store_true", default=False,
+                        help="treat fastq as interleaved read pairs")
+
 
 def run_split_fastq(job, options, graph_file_id, xg_file_id, gcsa_and_lcp_ids, sample_fastq_id):
     
@@ -161,13 +164,16 @@ def run_alignment(job, options, chunk_filename_id, chunk_id, graph_file_id, xg_f
 
         # Plan out what to run
         vg_parts = []
-        if hasattr(options, 'vg_map_args'):
-            vg_parts += ['vg', 'map', '-f', os.path.basename(fastq_file), os.path.basename(graph_file)]
-            vg_parts += options.vg_map_args
-        else:
-            vg_parts = ['vg', 'map', '-f', os.path.basename(fastq_file),
-                        '-i', '-M2', '-W', '500', '-u', '0', '-U',
-                        '-O', '-S', '50', '-a', '-t', str(job.cores), os.path.basename(graph_file)]
+        vg_parts += ['vg', 'map', '-f', os.path.basename(fastq_file), os.path.basename(graph_file)]
+        vg_parts += options.vg_map_args
+
+        # Override the -i flag in args with the --interleaved command-line flag
+        if options.interleaved is True and '-i' not in vg_parts and '--interleaved' not in vg_parts:
+            vg_parts += ['-i']
+        elif options.interleaved is False and 'i' in vg_parts:
+            del vg_parts[vg_parts.index('-i')]
+        if options.interleaved is False and '--interleaved' in vg_parts:
+            del vg_parts[vg_parts.index('--interleaved')]
 
         if options.index_mode == "gcsa-kmer":
             # Use the new default context size in this case


### PR DESCRIPTION
By default, assume fastq file reads are not paired.  --interleaved turns on support. 

The corresponding option in vg_map_args, -i, is overridden completely. 

--interleave is only activated for the first test.  All other tests are treated as non-paired (as otherwise the fastq files are invalid).  The normal files have been updated accordingly.  