### PR TITLE
Move toil resource parameter values to config

### DIFF
--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -34,7 +34,7 @@ def add_common_vg_parse_args(parser):
     parser.add_argument("--force_outstore", action="store_true",
                         help="use output store instead of toil for all intermediate files (use only for debugging)")
 
-    parser.add_argument("--path_name", nargs='+', default=[],
+    parser.add_argument("--path_name", nargs='+', 
         help="Name of reference path in the graph. Usually chromosome name (eg. ref or 17).  "
                         "Can specifiy multiple names separated by spaces.")
 

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -86,9 +86,8 @@ on and off in just one place.  to do: Should go somewhere more central """
         list has size > 1, then piping interface used """
 
         RealTimeLogger.get().info("Docker Run: {}".format(" | ".join(" ".join(x) for x in args)))
-        print('')
-        print('ARGS: ', args)
-        print('DOCKER TOOL MAP: ', self.docker_tool_map)
+        start_time = timeit.default_timer()
+        
         if len(args) == 1:
             # just one command, use regular docker_call interface
             # where parameters is an argument list not including command
@@ -117,20 +116,25 @@ on and off in just one place.  to do: Should go somewhere more central """
             tool = None
             tools = str(self.docker_tool_map[args[0][0]][0])
             parameters = [" ".join(x) for x in args]
-        print('')
-        print('PARAMETERS: ', parameters)
-        print('TOOL: ', tool)
-        print('TOOLS: ', tools)
-        return docker_call(tool=tool, tools=tools, parameters=parameters,
+
+        ret = docker_call(tool=tool, tools=tools, parameters=parameters,
                            work_dir=work_dir, outfile = outfile,
                            errfile = errfile,
                            check_output = check_output,
                            inputs=inputs)
 
+        end_time = timeit.default_timer()
+        run_time = end_time - start_time
+        RealTimeLogger.get().info("Successfully docker ran {} in {} seconds.".format(
+            " | ".join(" ".join(x) for x in args), run_time))
+
+        return ret
+
     def call_directly(self, args, work_dir, outfile, errfile, check_output, inputs):
         """ Just run the command without docker """
 
         RealTimeLogger.get().info("Run: {}".format(" | ".join(" ".join(x) for x in args)))
+        start_time = timeit.default_timer()
 
         # this is all that docker_call does with the inputs parameter:
         for filename in inputs:
@@ -155,6 +159,11 @@ on and off in just one place.  to do: Should go somewhere more central """
             if sts != 0:            
                 raise Exception("Command {} returned with non-zero exit status {}".format(
                     " ".join(args[i]), sts))
+
+        end_time = timeit.default_timer()
+        run_time = end_time - start_time
+        RealTimeLogger.get().info("Successfully ran {} in {} seconds.".format(
+            " | ".join(" ".join(x) for x in args), run_time))            
 
         if check_output:
             return output

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -19,7 +19,7 @@ from toil_lib import require
 # TODO: configure RPATH-equivalent on OS X for finding libraries without environment variables at runtime
 def generate_config():
     return textwrap.dedent("""
-        # Toil VG Pipeline configuration file
+        # Toil VG Pipeline configuration file (created by toil-vg generate-config)
         # This configuration file is formatted in YAML. Simply write the value (at least one space) after the colon.
         # Edit the values in the configuration file and then rerun the pipeline: "toil-vg run"
         # 
@@ -27,139 +27,148 @@ def generate_config():
         # Local inputs follow the URL convention: "/full/path/to/input.txt"
         # S3 URLs follow the convention: "s3://bucket/directory/file.txt"
         #
-        # Comments (beginning with #) do not need to be removed. Optional parameters left blank are treated as false or blank.
+        # Comments (beginning with #) do not need to be removed. 
+        # Command-line options take priority over parameters in this file.  
         ######################################################################################################################
 
         ###########################################
+        ### Toil resource tuning                ###
+        
+        # These parameters must be adjusted based on data and cluster size
+        # when running on anything other than single-machine mode
+
+        # TODO: Reduce number of parameters here.  Seems fine grained, especially for disk/mem
+        # option to spin off config files for small/medium/large datasets?   
+
+        # The following parameters assign resources to small helper jobs that typically don't do 
+        # do any computing outside of toil overhead.  Generally do not need to be changed. 
+        misc-cores: 1
+        misc-mem: '1G'
+        misc-disk: '1G'
+
+        # Resources allotted for xg and gcaa indexing. 
+        index-cores: 1
+        index-mem: '4G'
+        index-disk: '2G'
+
+        # Resources for fastq splitting and gam merging
+        # (current simplementation is single threaded for both)
+        fq-split-cores: 1
+        fq-split-mem: '4G'
+        fq-split-disk: '2G'
+
+        # Number of threads to use for Rocksdb GAM indexing
+        # Generally, this should be kept low as speedup drops off radically 
+        # after a few threads.
+        gam-index-cores: 1
+
+        # Resources for *each* vg map job
+        # the number of vg map jobs is controlled by num-fastq-chunks (below)
+        alignment-cores: 1
+        alignment-mem: '4G'
+        alignment-disk: '2G'
+
+        # Resources for chunking up a graph/gam for calling (and merging)
+        # typically take xg for whoe grpah, and gam for a chromosome,
+        # and split up into chunks of call-chunk-size (below)
+        call-chunk-cores: 1
+        call-chunk-mem: '4G'
+        call-chunk-disk: '2G'
+
+        # Resources for calling each chunk (currently includes pileup/call/genotype)
+        calling-cores: 1
+        calling-mem: '4G'
+        calling-disk: '2G'
+
+        ###########################################
         ### Arguments Shared Between Components ###
-        # Optional: Use output store instead of toil for all intermediate files (use only for debugging)
+        # Use output store instead of toil for all intermediate files (use only for debugging)
         force-outstore: False
 
-        # Optional: Use the following reference paths.  Some possibilities for whole human genome below:
+        # Use the following reference paths.  Some possibilities for whole human genome below:
         # path-name: ['1', '2', '3', '4', '5', '6', '7', '8' '9' '10', '11', '12', '13', '14', '15', 16', '17', '18', '19', '20', '21', '22', 'X', 'Y']
         # path-name: ['1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6', 'chr7', 'chr8' '9' '10', 'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 16', 'chr17', 'chr18', 'chr19', 'chr20', 'chr21', 'chr22', 'chrX', 'chrY']
-
         
         #############################
         ### Docker Tool Arguments ###
-        # Optional: Do not use docker for any commands
+        # Do not use docker for any commands
         no-docker: False
         
         ## Docker Tool List ##
         ##   Each tool is specified as a list where the first element is the docker image URL,
         ##   and the second element indicates if the docker image has an entrypoint or not
-        ##   If left blank, then the tool will be run directly from the command line instead
-        ##   of through docker
-        # Optional: Dockerfile to use for vg
+        ##   If left blank or commented, then the tool will be run directly from the command line instead
+        ##   of through docker. no-docker (above) overrides all these options. 
+        # Dockerfile to use for vg
 
         vg-docker: ['quay.io/glennhickey/vg:v1.4.0-1980-g38453bf', True]
 
-        # Optional: Dockerfile to use for bcftools
+        # Dockerfile to use for bcftools
         bcftools-docker: ['quay.io/cmarkello/bcftools', False]
 
-        # Optional: Dockerfile to use for tabix
+        # Dockerfile to use for tabix
         tabix-docker: ['quay.io/cmarkello/htslib:latest', False]
 
-        # Optional: Dockerfile to use for jq
+        # Dockerfile to use for jq
         jq-docker: ['devorbitus/ubuntu-bash-jq-curl', False]
         
-        # Optional: Dockerfile to use for rtg
+        # Dockerfile to use for rtg
         rtg-docker: ['realtimegenomics/rtg-tools:3.7.1', True]
         
         ##########################
         ### vg_index Arguments ###
-        # Optional: Maximum edges to cross in index
+        # Maximum edges to cross in index
         edge-max: 5
 
-        # Optional: Size of kmers to use in indexing and mapping
+        # Size of kmers to use in indexing and mapping
         kmer-size: 10
 
-        # Optional: Don't re-use existing indexed graphs
-        reindex: False
-
-        # Optional: Use the pruned graph in the index
+        # Use the pruned graph in the index
         include-pruned: False
-
-        # Optional: Use the primary path in the index
-        include-primary: True
-
-        # Optional: Number of threads during the indexing step
-        index-cores: 4
-
-        # Optional: Toil job memory allocation for indexing
-        index-mem: '4G'
-
-        # Optional: Toil job disk allocation for indexing
-        index-disk: '2G'
 
         ########################
         ### vg_map Arguments ###
-        # Optional: Number of chunks to split the input fastq file records
+
+        # Number of chunks to split the input fastq file records
         num-fastq-chunks: 3
         
-        # Optional: Number of threads during the alignment step
-        alignment-cores: 3
-
-        # Optional: Number of threads to use for Rocksdb GAM indexing
-        # Generally, this should be kept low as speedup drops off radically 
-        # after a few threads.
-        gam-index-cores: 3
-
-        # Optional: Context expansion used for gam chunking
-        chunk_context: 20
+        # Context expansion used for gam chunking
+        chunk_context: 50
+    
+        # Treat input fastq as paired-end interleaved
+        interleaved: False
         
-        # Core arguments for vg mapping
+        # Core arguments for vg mapping (do not include file names or -t/--threads)
         # Note -i/--interleaved will be ignored. use the --interleaved option 
         # on the toil-vg command line instead
-        vg-map-args: ['-M2', '-W', '500', '-u', '0', '-U', '-O', '-S', '50', '-a']
+        map-opts: ['-M2', '-W', '500', '-u', '0', '-U', '-O', '-S', '50', '-a']
         
-        # Optional: Toil job memory allocation for mapping
-        alignment-mem: '4G'
-        
-        # Optional: Toil job disk allocation for mapping
-        alignment-disk: '2G'
-
-        # Optional: Type of vg index to use for mapping (either 'gcsa-kmer' or 'gcsa-mem')
+        # Type of vg index to use for mapping (either 'gcsa-kmer' or 'gcsa-mem')
         index-mode: gcsa-mem
-
 
         #########################
         ### vg_call Arguments ###
-        # Optional: Overlap option that is passed into make_chunks and call_chunk
+        # Overlap option that is passed into make_chunks and call_chunk
         overlap: 2000
         
-        # Optional: Chunk size
+        # Chunk size
         call-chunk-size: 10000000
 
-        # Optional: Chromosomal position offset (eg. 43044293)
-        offset: None
-
-        # Optional: Options to pass to chunk_gam.
+        # Options to pass to chunk_gam. (do not include file names or -t/--threads)
         filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15']
 
-        # Optional: Options to pass to vg pileup.
+        # Options to pass to vg pileup. (do not include file names or -t/--threads)
         pileup-opts: ['-q', '10', '-a']
 
-        # Optional: Options to pass to vg call.
+        # Options to pass to vg call. (do not include file names or -t/--threads)
         call-opts: ['']
         
-        # Optional: Options to pass to vg genotype.
+        # Options to pass to vg genotype. (do not include file names or -t/--threads)
         genotype-opts: ['']
 
-        # Optional: Use vg genotype instead of vg call
+        # Use vg genotype instead of vg call
         genotype: False
-
-        # Optional: Number of threads during the variant calling step
-        calling-cores: 4
         
-        # Optional: Toil job memory allocation for variant calling
-        calling-mem: '4G'
-        
-        # Optional: Toil job disk allocation for variant calling
-        calling-disk: '2G'
-        
-        # Optional: always overwrite existing files
-        overwrite: False
     """)
 
 
@@ -167,6 +176,16 @@ def apply_config_file_args(args):
     """
     Merge args from the config file and the parser, giving priority to the parser.
     """
+
+    # turn --*_opts from strings to lists to be consistent with config file
+    for x_opts in ['map_opts', 'call_opts', 'filter_opts', 'genotype_opts']:
+        if x_opts in args.__dict__.keys() and type(args.__dict__[x_opts]) is str:
+            args.__dict__[x_opts] = args.__dict__[x_opts].split(' ')
+            # get rid of any -t or --threads while we're at it
+            for t in ['-t', '--threads']:
+                if t in args.__dict__[x_opts]:
+                    pos = args.__dict__[x_opts].index(t)
+                    del args.__dict__[x_opts][pos:pos+2]
 
     # If no config file given, we generate a default one
     if args.config is None:


### PR DESCRIPTION
* Do not hardcode any cores, disk, or memory values in the python.  Move them all to config
* Centralize these resources into one config section

There's still work to do, namely:
* Sensible defaults (all super low now). 
* Merge up some of these, probably overkill to have so many different ones
* Look into having a few different default configs for small/medium/big datasets

But will have to tune by hand on larger datasets before coming back to this.. .