### PR TITLE
Speed up fastq chunking

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -54,9 +54,9 @@ class VGCGLTest(TestCase):
                 
         self.base_command = concat('toil-vg', 'run',
                                    '--realTimeLogging', '--logInfo', '--edge_max', '5', '--kmer_size',
-                                   '16', '--num_fastq_chunks', '4', '--call_chunk_size', '20000',
-                                   '--index_mode', 'gcsa-mem', '--index_cores', '8', '--alignment_cores', '8',
-                                   '--calling_cores', '8')
+                                   '16', '--reads_per_chunk', '8000', '--call_chunk_size', '20000',
+                                   '--index_mode', 'gcsa-mem', '--index_cores', '7', '--alignment_cores', '4',
+                                   '--calling_cores', '4')
         
         # default output store
         self.outstore = 'aws:us-west-2:toilvg-jenkinstest-outstore-{}'.format(uuid4())

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -52,7 +52,7 @@ def generate_config():
         index-disk: '2G'
 
         # Resources for fastq splitting and gam merging
-        # (current simplementation is single threaded for both)
+        # fastq spilt can use up to 2 cores, gam merging single threaded
         fq-split-cores: 1
         fq-split-mem: '4G'
         fq-split-disk: '2G'
@@ -63,7 +63,7 @@ def generate_config():
         gam-index-cores: 1
 
         # Resources for *each* vg map job
-        # the number of vg map jobs is controlled by num-fastq-chunks (below)
+        # the number of vg map jobs is controlled by reads-per-chunk (below)
         alignment-cores: 1
         alignment-mem: '4G'
         alignment-disk: '2G'
@@ -129,8 +129,9 @@ def generate_config():
         ########################
         ### vg_map Arguments ###
 
-        # Number of chunks to split the input fastq file records
-        num-fastq-chunks: 3
+        # Number of reads per chunk to use when splitting up fastq.  
+        # Each chunk will correspond to a vg map job
+        reads-per-chunk: 10000000
         
         # Context expansion used for gam chunking
         chunk_context: 50

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -104,20 +104,20 @@ def run_split_fastq(job, options, sample_fastq_id):
     # 4 lines per read
     chunk_lines = chunk_size * 4
 
-    # TODO: Would like to pipe bgzip to split, but can't figure
+    # TODO: Would like to pipe gzip to split, but can't figure
     # out how to do with current docker interface.
 
     # Unzip the input reads if necessary, the result will be BIG
     if fastq_gzipped:
         uc_fastq_path = os.path.join(work_dir, 'input_reads.fq')
         with open(uc_fastq_path, 'w') as uc_file:
-            cmd = ['bgzip', '-d', '-c', os.path.basename(fastq_path)]
+            cmd = ['gzip', '-d', '-c', os.path.basename(fastq_path)]
             options.drunner.call(cmd, work_dir = work_dir, outfile = uc_file)
     else:
         uc_fastq_path = fastq_path
 
     # Split using split
-    cmd = ['split', '-l', str(chunk_lines), '--filter=bgzip > $FILE.fq.gz',
+    cmd = ['split', '-l', str(chunk_lines), '--filter=gzip > $FILE.fq.gz',
            os.path.basename(uc_fastq_path), 'fq_chunk.']
     options.drunner.call(cmd, work_dir = work_dir)
 


### PR DESCRIPTION
Was taking 45 min to do chr22, which would mean days for whole genome.  
Changes
* instead of using Python interface, use gzip and split subprocess / docker calls. 
* launch gam-splitting job concurrently with indexing

Would be nice to have gzip | split, without writing uncompressed file to disk (as implemented), but would need to figure a work-around for docker.  Current version still many times faster than before. 