### PR TITLE
Remove toil-lib dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,15 +96,11 @@ check_build_reqs:
 
 
 prepare: check_venv
-	rm -fr ${PWD}/toil-lib
-	git clone --recursive https://github.com/cmarkello/toil-lib.git ${PWD}/toil-lib/
 	$(pip) install numpy==1.11.2
 	$(pip) install pytest==2.8.3 toil[aws,mesos]==3.5.0a1.dev241 biopython==1.67
-	$(pip) install ${PWD}/toil-lib/
 	pip list
 clean_prepare: check_venv
-	rm -rf ${PWD}/toil-lib/
-	- $(pip) uninstall -y pytest toil-lib biopython numpy
+	- $(pip) uninstall -y pytest biopython numpy
 
 check_venv:
 	@$(python) -c 'import sys; sys.exit( int( not hasattr(sys, "real_prefix") ) )' \

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ kwargs = dict(
     author_email='cgl-toil@googlegroups.com',
     url="https://github.com/BD2KGenomics/toil-vg",
     install_requires=[x + y for x, y in required_versions.iteritems()],
-    dependency_links=['git+https://github.com/cmarkello/toil-lib.git#egg=toil-lib-1.1.0a1'],
+    dependency_links=[],
     tests_require=['pytest==2.8.3'],
     package_dir={'': 'src'},
     packages=find_packages('src'),

--- a/src/toil_vg/docker.py
+++ b/src/toil_vg/docker.py
@@ -1,0 +1,262 @@
+"""
+    Module for calling Docker. Assumes `docker` is on the PATH.
+
+    Contains two user-facing functions: dockerCall and dockerCheckOutput
+
+    Uses Toil's defer functionality to ensure containers are shutdown even in case of job or pipeline failure
+
+    Example of using dockerCall in a Toil pipeline to index a FASTA file with SAMtools:
+        def toil_job(job):
+            work_dir = job.fileStore.getLocalTempDir()
+            path = job.fileStore.readGlobalFile(ref_id, os.path.join(work_dir, 'ref.fasta')
+            parameters = ['faidx', path]
+            dockerCall(job, tool='quay.io/ucgc_cgl/samtools:latest', work_dir=work_dir, parameters=parameters)
+"""
+import base64
+import logging
+import subprocess
+
+import os
+from bd2k.util.exceptions import require
+
+_logger = logging.getLogger(__name__)
+
+
+def dockerCall(job,
+               tool,
+               parameters=None,
+               workDir=None,
+               dockerParameters=None,
+               outfile=None,
+               defer=None):
+    """
+    Throws CalledProcessorError if the Docker invocation returns a non-zero exit code
+    This function blocks until the subprocess call to Docker returns
+
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Docker image to be used (e.g. quay.io/ucsc_cgl/samtools:latest).
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+           If list of lists: list[list[str]], then treat as succesive commands chained with pipe.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] dockerParameters: Parameters to pass to Docker. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if docker_parmaters is passed, so be sure to pass them if they are desired.
+    :param file outfile: Pipe output of Docker call to file handle
+    :param int defer: What action should be taken on the container upon job completion?
+           FORGO (0) will leave the container untouched.
+           STOP (1) will attempt to stop the container with `docker stop` (useful for debugging).
+           RM (2) will stop the container and then forcefully remove it from the system
+           using `docker rm -f`. This is the default behavior if defer is set to None.
+    """
+    _docker(job, tool=tool, parameters=parameters, workDir=workDir, dockerParameters=dockerParameters,
+            outfile=outfile, checkOutput=False, defer=defer)
+
+
+def dockerCheckOutput(job,
+                      tool,
+                      parameters=None,
+                      workDir=None,
+                      dockerParameters=None,
+                      defer=None):
+    """
+    Returns the stdout from the Docker invocation (via subprocess.check_output)
+    Throws CalledProcessorError if the Docker invocation returns a non-zero exit code
+    This function blocks until the subprocess call to Docker returns
+
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Docker image to be used (e.g. quay.io/ucsc_cgl/samtools:latest).
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+           If list of lists: list[list[str]], then treat as succesive commands chained with pipe.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] dockerParameters: Parameters to pass to Docker. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if docker_parmaters is passed, so be sure to pass them if they are desired.
+    :param int defer: What action should be taken on the container upon job completion?
+           FORGO (0) will leave the container untouched.
+           STOP (1) will attempt to stop the container with `docker stop` (useful for debugging).
+           RM (2) will stop the container and then forcefully remove it from the system
+           using `docker rm -f`. This is the default behavior if defer is set to None.
+    :returns: Stdout from the docker call
+    :rtype: str
+    """
+    return _docker(job, tool=tool, parameters=parameters, workDir=workDir,
+                   dockerParameters=dockerParameters, checkOutput=True, defer=defer)
+
+
+def _docker(job,
+            tool,
+            parameters=None,
+            workDir=None,
+            dockerParameters=None,
+            outfile=None,
+            checkOutput=False,
+            defer=None):
+    """
+    :param toil.Job.job job: The Job instance for the calling function.
+    :param str tool: Name of the Docker image to be used (e.g. quay.io/ucsc_cgl/samtools).
+    :param list[str] parameters: Command line arguments to be passed to the tool.
+           If list of lists: list[list[str]], then treat as succesive commands chained with pipe.
+    :param str workDir: Directory to mount into the container via `-v`. Destination convention is /data
+    :param list[str] dockerParameters: Parameters to pass to Docker. Default parameters are `--rm`,
+            `--log-driver none`, and the mountpoint `-v work_dir:/data` where /data is the destination convention.
+             These defaults are removed if docker_parmaters is passed, so be sure to pass them if they are desired.
+    :param file outfile: Pipe output of Docker call to file handle
+    :param bool checkOutput: When True, this function returns docker's output.
+    :param int defer: What action should be taken on the container upon job completion?
+           FORGO (0) will leave the container untouched.
+           STOP (1) will attempt to stop the container with `docker stop` (useful for debugging).
+           RM (2) will stop the container and then forcefully remove it from the system
+           using `docker rm -f`. This is the default behavior if defer is set to None.
+    """
+    if parameters is None:
+        parameters = []
+    if workDir is None:
+        workDir = os.getcwd()
+
+    # Setup the outgoing subprocess call for docker
+    baseDockerCall = ['docker', 'run']
+    if dockerParameters:
+        baseDockerCall += dockerParameters
+    else:
+        baseDockerCall += ['--rm', '--log-driver', 'none', '-v',
+                           os.path.abspath(workDir) + ':/data']
+
+    # Ensure the user has passed a valid value for defer
+    require(defer in (None, FORGO, STOP, RM),
+            'Please provide a valid value for defer.')
+
+    # Get container name which is needed for _dockerKill
+    try:
+        if any('--name' in x for x in baseDockerCall):
+            if any('--name=' in x for x in baseDockerCall):
+                containerName = [x.split('=')[1] for x in baseDockerCall if '--name' in x][0]
+            else:
+                containerName = baseDockerCall[baseDockerCall.index('--name') + 1]
+        else:
+            containerName = _getContainerName(job)
+    except ValueError:
+        containerName = _getContainerName(job)
+        baseDockerCall.extend(['--name', containerName])
+    except IndexError:
+        raise RuntimeError("Couldn't parse Docker's `--name=` option, check parameters: " + str(dockerParameters))
+
+    # Defer the container on-exit action
+    if '--rm' in baseDockerCall and defer is None:
+        defer = RM
+    if '--rm' in baseDockerCall and defer is not RM:
+        _logger.warn('--rm being passed to docker call but defer not set to dockerCall.RM, defer set to: ' + str(defer))
+    job.defer(_dockerKill, containerName, action=defer)
+    # Defer the permission fixing function which will run after this job concludes.
+    # We call this explicitly later on in this function, but we defer it as well to handle unexpected job failure.
+    job.defer(_fixPermissions, tool, workDir)
+
+    # Make subprocess call
+
+    # If parameters is list of lists, treat each list as separate command and chain with pipes
+    if len(parameters) > 0 and type(parameters[0]) is list:
+        # When piping, all arguments get passed as a single string to bash -c.
+        # We try to support spaces in paths by wrapping them all in quotes first.
+        quoted_params = []
+        for params in parameters:
+            quoted_params.append(['\'{}\''.format(p) for p in params])
+        chain_params = [' '.join(p) for p in quoted_params]
+        call = baseDockerCall + ['--entrypoint', '/bin/bash',  tool, '-c', ' | '.join(chain_params)]
+    else:
+        call = baseDockerCall + [tool] + parameters
+    _logger.info("Calling docker with " + repr(call))
+
+    if outfile:
+        subprocess.check_call(call, stdout=outfile)
+    else:
+        if checkOutput:
+            return subprocess.check_output(call)
+        else:
+            subprocess.check_call(call)
+
+
+FORGO = 0
+STOP = 1
+RM = 2
+
+
+def _dockerKill(containerName, action):
+    """
+    Kills the specified container.
+    :param str containerName: The name of the container created by docker_call
+    :param int action: What action should be taken on the container?  See `defer=` in
+           :func:`docker_call`
+    """
+    running = _containerIsRunning(containerName)
+    if running is None:
+        # This means that the container doesn't exist.  We will see this if the container was run
+        # with --rm and has already exited before this call.
+        _logger.info('The container with name "%s" appears to have already been removed.  Nothing to '
+                  'do.', containerName)
+    else:
+        if action in (None, FORGO):
+            _logger.info('The container with name %s continues to exist as we were asked to forgo a '
+                      'post-job action on it.', containerName)
+        else:
+            _logger.info('The container with name %s exists. Running user-specified defer functions.',
+                         containerName)
+            if running and action >= STOP:
+                _logger.info('Stopping container "%s".', containerName)
+                subprocess.check_call(['docker', 'stop', containerName])
+            else:
+                _logger.info('The container "%s" was not found to be running.', containerName)
+            if action >= RM:
+                # If the container was run with --rm, then stop will most likely remove the
+                # container.  We first check if it is running then remove it.
+                running = _containerIsRunning(containerName)
+                if running is not None:
+                    _logger.info('Removing container "%s".', containerName)
+                    subprocess.check_call(['docker', 'rm', '-f', containerName])
+                else:
+                    _logger.info('The container "%s" was not found on the system.  Nothing to remove.',
+                                 containerName)
+
+
+def _fixPermissions(tool, workDir):
+    """
+    Fix permission of a mounted Docker directory by reusing the tool to change ownership.
+    Docker natively runs as a root inside the container, and files written to the
+    mounted directory are implicitly owned by root.
+
+    :param list baseDockerCall: Docker run parameters
+    :param str tool: Name of tool
+    :param str workDir: Path of work directory to recursively chown
+    """
+    baseDockerCall = ['docker', 'run', '--log-driver=none',
+                      '-v', os.path.abspath(workDir) + ':/data', '--rm', '--entrypoint=chown']
+    stat = os.stat(workDir)
+    command = baseDockerCall + [tool] + ['-R', '{}:{}'.format(stat.st_uid, stat.st_gid), '/data']
+    subprocess.check_call(command)
+
+
+def _getContainerName(job):
+    return '--'.join([str(job),
+                      job.fileStore.jobID,
+                      base64.b64encode(os.urandom(9), '-_')]).replace("'", '').replace('_', '')
+
+
+def _containerIsRunning(container_name):
+    """
+    Checks whether the container is running or not.
+    :param container_name: Name of the container being checked.
+    :returns: True if running, False if not running, None if the container doesn't exist.
+    :rtype: bool
+    """
+    try:
+        output = subprocess.check_output(['docker', 'inspect', '--format', '{{.State.Running}}',
+                                          container_name]).strip()
+    except subprocess.CalledProcessError:
+        # This will be raised if the container didn't exist.
+        _logger.debug("'docker inspect' failed. Assuming container %s doesn't exist.", container_name,
+                   exc_info=True)
+        return None
+    if output == 'true':
+        return True
+    elif output == 'false':
+        return False
+    else:
+        raise RuntimeError("Got unexpected value for State.Running (%s)" % output)

--- a/src/toil_vg/iostore.py
+++ b/src/toil_vg/iostore.py
@@ -1,0 +1,905 @@
+"""
+IOStore class originated here 
+
+https://github.com/BD2KGenomics/hgvm-graph-bakeoff-evaluations/blob/master/scripts/toillib.py
+
+and was then here:
+
+https://github.com/cmarkello/toil-lib/blob/master/src/toil_lib/toillib.py
+
+In a perfect world, this would be deprecated and replaced with Toil's stores. 
+
+Actually did this here:
+
+https://github.com/glennhickey/toil-vg/tree/issues/110-fix-iostore
+
+But couldn't get Toil's multipart S3 uploader working on large files.  Also,
+the toil jobStore interface is a little less clean for our use. 
+
+So for now keep as part of toil-vg where it works.  Could also consider merging
+into the upstream toil-lib
+
+https://github.com/BD2KGenomics/toil-lib
+"""
+
+
+import sys, os, os.path, json, collections, logging, logging.handlers
+import SocketServer, struct, socket, threading, tarfile, shutil
+import tempfile
+import functools
+import random
+import time
+import traceback
+import stat
+from toil.realtimeLogger import RealtimeLogger
+
+import datetime
+
+# Need stuff for Amazon s3
+try:
+    import boto3
+    have_s3 = True
+except ImportError:
+    have_s3 = False
+    pass
+
+# We need some stuff in order to have Azure
+try:
+    import azure
+    # Make sure to get the 0.11 BlobService, in case the new azure storage
+    # module is also installed.
+    from azure.storage.blob import BlobService
+    import toil.jobStores.azureJobStore
+    have_azure = True
+except ImportError:
+    have_azure = False
+    pass
+    
+def robust_makedirs(directory):
+    """
+    Make a directory when other nodes may be trying to do the same on a shared
+    filesystem.
+    
+    """
+
+    if not os.path.exists(directory):
+        try:
+            # Make it if it doesn't exist
+            os.makedirs(directory)
+        except OSError:
+            # If you can't make it, maybe someone else did?
+            pass
+            
+    # Make sure it exists and is a directory
+    assert(os.path.exists(directory) and os.path.isdir(directory))
+
+
+def write_global_directory(file_store, path, cleanup=False, tee=None, compress=True):
+    """
+    Write the given directory into the file store, and return an ID that can be
+    used to retrieve it. Writes the files in the directory and subdirectories
+    into a tar file in the file store.
+
+    Does not preserve the name or permissions of the given directory (only of
+    its contents).
+
+    If cleanup is true, directory will be deleted from the file store when this
+    job and its follow-ons finish.
+    
+    If tee is passed, a tar.gz of the directory contents will be written to that
+    filename. The file thus created must not be modified after this function is
+    called.
+    
+    """
+    
+    write_stream_mode = "w"
+    if compress:
+        write_stream_mode = "w|gz"
+    
+    if tee is not None:
+        with open(tee, "w") as file_handle:
+            # We have a stream, so start taring into it
+            with tarfile.open(fileobj=file_handle, mode=write_stream_mode) as tar:
+                # Open it for streaming-only write (no seeking)
+                
+                # We can't just add the root directory, since then we wouldn't be
+                # able to extract it later with an arbitrary name.
+                
+                for file_name in os.listdir(path):
+                    # Add each file in the directory to the tar, with a relative
+                    # path
+                    tar.add(os.path.join(path, file_name), arcname=file_name)
+        
+        # Save the file on disk to the file store.
+        return file_store.writeGlobalFile(tee)
+    else:
+    
+        with file_store.writeGlobalFileStream(cleanup=cleanup) as (file_handle,
+            file_id):
+            # We have a stream, so start taring into it
+            # TODO: don't duplicate this code.
+            with tarfile.open(fileobj=file_handle, mode=write_stream_mode) as tar:
+                # Open it for streaming-only write (no seeking)
+                
+                # We can't just add the root directory, since then we wouldn't be
+                # able to extract it later with an arbitrary name.
+                
+                for file_name in os.listdir(path):
+                    # Add each file in the directory to the tar, with a relative
+                    # path
+                    tar.add(os.path.join(path, file_name), arcname=file_name)
+                    
+            # Spit back the ID to use to retrieve it
+            return file_id
+        
+def read_global_directory(file_store, directory_id, path):
+    """
+    Reads a directory with the given tar file id from the global file store and
+    recreates it at the given path.
+    
+    The given path, if it exists, must be a directory.
+    
+    Do not use to extract untrusted directories, since they could sneakily plant
+    files anywhere on the filesystem.
+    
+    """
+    
+    # Make the path
+    robust_makedirs(path)
+    
+    with file_store.readGlobalFileStream(directory_id) as file_handle:
+        # We need to pull files out of this tar stream
+    
+        with tarfile.open(fileobj=file_handle, mode="r|*") as tar:
+            # Open it for streaming-only read (no seeking)
+            
+            # We need to extract the whole thing into that new directory
+            tar.extractall(path)
+            
+
+class IOStore(object):
+    """
+    A class that lets you get your input files and save your output files
+    to/from a local filesystem, Amazon S3, or Microsoft Azure storage
+    transparently.
+    
+    This is the abstract base class; other classes inherit from this and fill in
+    the methods.
+    
+    """
+    
+    def __init__(self):
+        """
+        Make a new IOStore
+        """
+        
+        raise NotImplementedError()
+            
+    def read_input_file(self, input_path, local_path):
+        """
+        Read an input file from wherever the input comes from and send it to the
+        given path.
+        
+        If the file at local_path already exists, it is overwritten.
+        
+        If the file at local_path already exists and is a directory, behavior is
+        undefined.
+        
+        """
+        
+        raise NotImplementedError()
+        
+    def list_input_directory(self, input_path, recursive=False,
+        with_times=False):
+        """
+        Yields each of the subdirectories and files in the given input path.
+        
+        If recursive is false, yields files and directories in the given
+        directory. If recursive is true, yields all files contained within the
+        current directory, recursively, but does not yield folders.
+        
+        If with_times is True, yields (name, modification time) pairs instead of
+        just names, with modification times represented as datetime objects in
+        the GMT timezone. Modification times may be None on objects that do not
+        support them.
+        
+        Gives relative file/directory names.
+        
+        """
+        
+        raise NotImplementedError()
+    
+    def write_output_file(self, local_path, output_path):
+        """
+        Save the given local file to the given output path. No output directory
+        needs to exist already.
+        
+        If the output path already exists, it is overwritten.
+        
+        If the output path already exists and is a directory, behavior is
+        undefined.
+        
+        """
+        
+        raise NotImplementedError()
+        
+    def exists(self, path):
+        """
+        Returns true if the given input or output file exists in the store
+        already.
+        
+        """
+        
+        raise NotImplementedError()
+        
+    def get_mtime(self, path):
+        """
+        Returns the modification time of the given gile if it exists, or None
+        otherwise.
+        
+        """
+        
+        raise NotImplementedError()
+        
+    @staticmethod
+    def get(store_string):
+        """
+        Get a concrete IOStore created from the given connection string.
+        
+        Valid formats are just like for a Toil JobStore, except with container
+        names being specified on Azure.
+        
+        Formats:
+        
+        /absolute/filesystem/path
+        
+        ./relative/filesystem/path
+        
+        file:filesystem/path
+        
+        aws:region:bucket (TODO)
+        
+        aws:region:bucket/path/prefix (TODO)
+        
+        azure:account:container (instead of a container prefix) (gets keys like
+        Toil)
+        
+        azure:account:container/path/prefix (trailing slash added automatically)
+        
+        """
+        
+        # Code adapted from toil's common.py loadJobStore()
+        
+        if store_string[0] in "/.":
+            # Prepend file: tot he path
+            store_string = "file:" + store_string
+
+        try:
+            # Break off the first colon-separated piece.
+            store_type, store_arguments = store_string.split(":", 1)
+        except ValueError:
+            # They probably forgot the . or /
+            raise RuntimeError("Incorrect IO store specification {}. "
+                "Local paths must start with . or /".format(store_string))
+
+        if store_type == "file":
+            return FileIOStore(store_arguments)
+        elif store_type == "aws":
+            # Break out the AWS arguments
+            region, bucket_name = store_arguments.split(":", 1)
+            return S3IOStore(region, bucket_name)
+            #raise NotImplementedError("AWS IO store not written")
+        elif store_type == "azure":
+            # Break out the Azure arguments.
+            account, container = store_arguments.split(":", 1)
+            
+            if "/" in container:
+                # Split the container from the path
+                container, path_prefix = container.split("/", 1)
+            else:
+                # No path prefix
+                path_prefix = ""
+            
+            return AzureIOStore(account, container, path_prefix)
+        else:
+            raise RuntimeError("Unknown IOStore implementation {}".format(
+                store_type))
+        
+        
+            
+class FileIOStore(IOStore):
+    """
+    A class that lets you get input from and send output to filesystem files.
+    
+    """
+    
+    def __init__(self, path_prefix=""):
+        """
+        Make a new FileIOStore that just treats everything as local paths,
+        relative to the given prefix.
+        
+        """
+        
+        self.path_prefix = path_prefix
+
+    def read_input_file(self, input_path, local_path):
+        """
+        Get input from the filesystem.
+        """
+        
+        RealtimeLogger.debug("Loading {} from FileIOStore in {} to {}".format(
+            input_path, self.path_prefix, local_path))
+        
+        if os.path.exists(local_path):
+            # Try deleting the existing item if it already exists
+            try:
+                os.unlink(local_path)
+            except:
+                # Don't fail here, fail complaining about the assertion, which
+                # will be more informative.
+                pass
+                
+        # Make sure the path is clear for copying
+        assert(not os.path.exists(local_path))
+        
+        # Where is the file actually?
+        real_path = os.path.abspath(os.path.join(self.path_prefix, input_path))
+        
+        if not os.path.exists(real_path):
+            RealtimeLogger.error(
+                "Can't find {} from FileIOStore in {}!".format(input_path,
+                self.path_prefix))
+            raise RuntimeError("File {} missing!".format(real_path))
+
+        # Make a temporary file
+        temp_handle, temp_path = tempfile.mkstemp(dir=os.path.dirname(local_path))
+        os.close(temp_handle)
+        
+        # Copy to the temp file
+        shutil.copy2(real_path, temp_path)
+            
+        # Rename the temp file to the right place, atomically
+        RealtimeLogger.info("rename {} -> {}".format(temp_path, local_path))
+        os.rename(temp_path, local_path)
+            
+        # Look at the file stats
+        file_stats = os.stat(real_path)
+        
+        if (file_stats.st_uid == os.getuid() and 
+            file_stats.st_mode & stat.S_IWUSR):
+            # We own this file and can write to it. We don't want the user
+            # script messing it up through the symlink.
+            
+            try:
+                # Clear the user write bit, so the user can't accidentally
+                # clobber the file in the actual store through the symlink.
+                os.chmod(real_path, file_stats.st_mode ^ stat.S_IWUSR)
+            except OSError:
+                # If something goes wrong here (like us not having permission to
+                # change permissions), ignore it.
+                pass
+                
+    def list_input_directory(self, input_path, recursive=False,
+        with_times=False):
+        """
+        Loop over directories on the filesystem.
+        """
+        
+        RealtimeLogger.info("Enumerating {} from "
+            "FileIOStore in {}".format(input_path, self.path_prefix))
+        
+        if not os.path.exists(os.path.join(self.path_prefix, input_path)):
+            # Nothing to list over
+            return
+            
+        if not os.path.isdir(os.path.join(self.path_prefix, input_path)):
+            # Can't list a file, only a directory.
+            return
+        
+        for item in os.listdir(os.path.join(self.path_prefix, input_path)):
+            if(recursive and os.path.isdir(os.path.join(self.path_prefix,
+                input_path, item))):
+                # We're recursing and this is a directory.
+                # Recurse on this.
+                for subitem in self.list_input_directory(
+                    os.path.join(input_path, item), recursive):
+                    
+                    # Make relative paths include this directory name and yield
+                    # them
+                    name_to_yield = os.path.join(item, subitem)
+                    
+                    if with_times:
+                        # What is the mtime in seconds since epoch?
+                        mtime_epoch_seconds = os.path.getmtime(os.path.join(
+                            input_path, item, subitem))
+                        # Convert it to datetime
+                            
+                        yield name_to_yield, mtime_epoch_seconds
+                    else:
+                        yield name_to_yield
+            else:
+                # This isn't a directory or we aren't being recursive
+                # Just report this individual item.
+                
+                if with_times:
+                    # What is the mtime in seconds since epoch?
+                    mtime_epoch_seconds = os.path.getmtime(os.path.join(
+                        input_path, item))
+                        
+                    yield item, mtime_epoch_seconds
+                else:
+                    yield item
+    
+    def write_output_file(self, local_path, output_path):
+        """
+        Write output to the filesystem
+        """
+
+        RealtimeLogger.debug("Saving {} to FileIOStore in {}".format(
+            output_path, self.path_prefix))
+
+        # What's the real output path to write to?
+        real_output_path = os.path.join(self.path_prefix, output_path)
+
+        # What directory should this go in?
+        parent_dir = os.path.split(real_output_path)[0]
+            
+        if parent_dir != "":
+            # Make sure the directory it goes in exists.
+            robust_makedirs(parent_dir)
+        
+        # Make a temporary file
+        temp_handle, temp_path = tempfile.mkstemp(dir=self.path_prefix)
+        os.close(temp_handle)
+        
+        # Copy to the temp file
+        shutil.copy2(local_path, temp_path)
+        
+        if os.path.exists(real_output_path):
+            # At least try to get existing files out of the way first.
+            os.unlink(real_output_path)
+            
+        # Rename the temp file to the right place, atomically
+        os.rename(temp_path, real_output_path)
+        
+    def exists(self, path):
+        """
+        Returns true if the given input or output file exists in the file system
+        already.
+        
+        """
+        
+        return os.path.exists(os.path.join(self.path_prefix, path))
+        
+    def get_mtime(self, path):
+        """
+        Returns the modification time of the given file if it exists, or None
+        otherwise.
+        
+        """
+        
+        raise NotImplementedError()
+
+class BackoffError(RuntimeError):
+    """
+    Represents an error from running out of retries during exponential back-off.
+    """
+
+def backoff_times(retries, base_delay):
+    """
+    A generator that yields times for random exponential back-off. You have to
+    do the exception handling and sleeping yourself. Stops when the retries run
+    out.
+    
+    """
+    
+    # Don't wait at all before the first try
+    yield 0
+    
+    # What retry are we on?
+    try_number = 1
+    
+    # Make a delay that increases
+    delay = float(base_delay) * 2
+    
+    while try_number <= retries:
+        # Wait a random amount between 0 and 2^try_number * base_delay
+        yield random.uniform(base_delay, delay)
+        delay *= 2
+        try_number += 1
+        
+    # If we get here, we're stopping iteration without succeeding. The caller
+    # will probably raise an error.
+        
+def backoff(original_function, retries=6, base_delay=10):
+    """
+    We define a decorator that does randomized exponential back-off up to a
+    certain number of retries. Raises BackoffError if the operation doesn't
+    succeed after backing off for the specified number of retries (which may be
+    float("inf")).
+    
+    Unfortunately doesn't really work on generators.
+    """
+    
+    # Make a new version of the function
+    @functools.wraps(original_function)
+    def new_function(*args, **kwargs):
+        # Call backoff times, overriding parameters with stuff from kwargs        
+        for delay in backoff_times(retries=kwargs.get("retries", retries),
+            base_delay=kwargs.get("base_delay", base_delay)):
+            # Keep looping until it works or our iterator raises a
+            # BackoffError
+            if delay > 0:
+                # We have to wait before trying again
+                RealtimeLogger.error("Retry after {} seconds".format(
+                    delay))
+                time.sleep(delay)
+            try:
+                return original_function(*args, **kwargs)
+            except:
+                # Report the formatted underlying exception with traceback
+                RealtimeLogger.error("{} failed due to: {}".format(
+                    original_function.__name__,
+                    "".join(traceback.format_exception(*sys.exc_info()))))
+        
+        
+        # If we get here, the function we're calling never ran through before we
+        # ran out of backoff times. Give an error.
+        raise BackoffError("Ran out of retries calling {}".format(
+            original_function.__name__))
+    
+    return new_function
+
+class S3IOStore(IOStore):
+    """
+    A class that lets you get input from and send output to AWS S3 Storage.
+    
+    """
+    
+    def __init__(self, region, bucket_name):
+        """
+        Make a new S3IOStore that reads from and writes to the given
+        container in the given account, adding the given prefix to keys. All
+        paths will be interpreted as keys or key prefixes.
+        
+        """
+        
+        # Make sure azure libraries actually loaded
+        assert(have_s3)
+        
+        self.region = region
+        self.bucket_name = bucket_name
+        self.s3 = None
+        
+    def __connect(self):
+        """
+        Make sure we have an S3 Bucket connection, and set one up if we don't.
+        Creates the S3 bucket if it doesn't exist.
+        """
+        
+        if self.s3 is None:
+            RealtimeLogger.debug("Connecting to bucket {} in region".format(
+                self.bucket_name, self.region))
+            
+            # Connect to the s3 bucket service where we keep everything
+            self.s3 = boto3.client('s3')
+            try:
+                self.s3.head_bucket(Bucket=self.bucket_name)            
+            except:
+                self.s3.create_bucket(Bucket=self.bucket_name,
+                                      CreateBucketConfiguration={'LocationConstraint':self.region})
+
+    def read_input_file(self, input_path, local_path):
+        """
+        Get input from S3.
+        """
+        
+        self.__connect()
+        
+        RealtimeLogger.debug("Loading {} from S3IOStore".format(
+            input_path))
+        
+        # Download the file contents.
+        self.s3.download_file(self.bucket_name, input_path, local_path)
+            
+    def list_input_directory(self, input_path, recursive=False,
+        with_times=False):
+        """
+        Yields each of the subdirectories and files in the given input path.
+        
+        If recursive is false, yields files and directories in the given
+        directory. If recursive is true, yields all files contained within the
+        current directory, recursively, but does not yield folders.
+        
+        If with_times is True, yields (name, modification time) pairs instead of
+        just names, with modification times represented as datetime objects in
+        the GMT timezone. Modification times may be None on objects that do not
+        support them.
+        
+        Gives relative file/directory names.
+        
+        """
+        
+        raise NotImplementedError()
+                
+    def write_output_file(self, local_path, output_path):
+        """
+        Write output to S3.
+        """
+        
+        self.__connect()
+        
+        RealtimeLogger.debug("Saving {} to S3IOStore".format(
+            output_path))
+
+        # Download the file contents.
+        self.s3.upload_file(local_path, self.bucket_name, output_path)
+    
+    def exists(self, path):
+        """
+        Returns true if the given input or output file exists in the store
+        already.
+        
+        """
+        
+        raise NotImplementedError()
+        
+    def get_mtime(self, path):
+        """
+        Returns the modification time of the given gile if it exists, or None
+        otherwise.
+        
+        """
+        
+        raise NotImplementedError()
+    
+class AzureIOStore(IOStore):
+    """
+    A class that lets you get input from and send output to Azure Storage.
+    
+    """
+    
+    def __init__(self, account_name, container_name, name_prefix=""):
+        """
+        Make a new AzureIOStore that reads from and writes to the given
+        container in the given account, adding the given prefix to keys. All
+        paths will be interpreted as keys or key prefixes.
+        
+        If the name prefix does not end with a trailing slash, and is not empty,
+        one will be added automatically.
+        
+        Account keys are retrieved from the AZURE_ACCOUNT_KEY environment
+        variable or from the ~/.toilAzureCredentials file, as in Toil itself.
+        
+        """
+        
+        # Make sure azure libraries actually loaded
+        assert(have_azure)
+        
+        self.account_name = account_name
+        self.container_name = container_name
+        self.name_prefix = name_prefix
+        
+        if self.name_prefix != "" and not self.name_prefix.endswith("/"):
+            # Make sure it has the trailing slash required.
+            self.name_prefix += "/"
+        
+        # Sneak into Toil and use the same keys it uses
+        self.account_key = toil.jobStores.azureJobStore._fetchAzureAccountKey(
+            self.account_name)
+            
+        # This will hold out Azure blob store connection
+        self.connection = None
+        
+    def __getstate__(self):
+        """
+        Return the state to use for pickling. We don't want to try and pickle
+        an open Azure connection.
+        """
+     
+        return (self.account_name, self.account_key, self.container_name, 
+            self.name_prefix)
+        
+    def __setstate__(self, state):
+        """
+        Set up after unpickling.
+        """
+        
+        self.account_name = state[0]
+        self.account_key = state[1]
+        self.container_name = state[2]
+        self.name_prefix = state[3]
+        
+        self.connection = None
+    
+    def __connect(self):
+        """
+        Make sure we have an Azure connection, and set one up if we don't.
+        """
+        
+        if self.connection is None:
+            RealtimeLogger.debug("Connecting to account {}, using "
+                "container {} and prefix {}".format(self.account_name,
+                self.container_name, self.name_prefix))
+        
+            # Connect to the blob service where we keep everything
+            self.connection = BlobService(
+                account_name=self.account_name, account_key=self.account_key)
+        
+            
+    @backoff        
+    def read_input_file(self, input_path, local_path):
+        """
+        Get input from Azure.
+        """
+        
+        self.__connect()
+        
+        
+        RealtimeLogger.debug("Loading {} from AzureIOStore".format(
+            input_path))
+        
+        # Download the blob. This is known to be synchronous, although it can
+        # call a callback during the process.
+        self.connection.get_blob_to_path(self.container_name,
+            self.name_prefix + input_path, local_path)
+            
+    def list_input_directory(self, input_path, recursive=False,
+        with_times=False):
+        """
+        Loop over fake /-delimited directories on Azure. The prefix may or may
+        not not have a trailing slash; if not, one will be added automatically.
+        
+        Returns the names of files and fake directories in the given input fake
+        directory, non-recursively.
+        
+        If with_times is specified, will yield (name, time) pairs including
+        modification times as datetime objects. Times on directories are None.
+        
+        """
+        
+        self.__connect()
+        
+        RealtimeLogger.info("Enumerating {} from AzureIOStore".format(
+            input_path))
+        
+        # Work out what the directory name to list is
+        fake_directory = self.name_prefix + input_path
+        
+        if fake_directory != "" and not fake_directory.endswith("/"):
+            # We have a nonempty prefix, and we need to end it with a slash
+            fake_directory += "/"
+        
+        # This will hold the marker that we need to send back to get the next
+        # page, if there is one. See <http://stackoverflow.com/a/24303682>
+        marker = None
+        
+        # This holds the subdirectories we found; we yield each exactly once if
+        # we aren't recursing.
+        subdirectories = set()
+        
+        while True:
+        
+            # Get the results from Azure. We don't use delimiter since Azure
+            # doesn't seem to provide the placeholder entries it's supposed to.
+            
+            result = self.connection.list_blobs(self.container_name, 
+                marker=marker)
+                
+            RealtimeLogger.info("Found {} files".format(len(result)))
+                
+            for blob in result:
+                # Yield each result's blob name, but directory names only once
+                
+                # Drop the common prefix
+                relative_path = blob.name
+                
+                if (not recursive) and "/" in relative_path:
+                    # We found a file in a subdirectory, and we aren't supposed
+                    # to be recursing.
+                    subdirectory, _ = relative_path.split("/", 1)
+                    
+                    if subdirectory not in subdirectories:
+                        # It's a new subdirectory. Yield and remember it
+                        subdirectories.add(subdirectory)
+                        
+                        if with_times:
+                            yield subdirectory, None
+                        else:
+                            yield subdirectory
+                else:
+                    # We found an actual file 
+                    yield relative_path
+                
+            # Save the marker
+            marker = result.next_marker
+                
+            if not marker:
+                break
+                
+    @backoff
+    def write_output_file(self, local_path, output_path):
+        """
+        Write output to Azure. Will create the container if necessary.
+        """
+        
+        self.__connect()
+        
+        RealtimeLogger.debug("Saving {} to AzureIOStore".format(
+            output_path))
+        
+        try:
+            # Make the container
+            self.connection.create_container(self.container_name)
+        except azure.WindowsAzureConflictError:
+            # The container probably already exists
+            pass
+        
+        # Upload the blob (synchronously)
+        # TODO: catch no container error here, make the container, and retry
+        self.connection.put_block_blob_from_path(self.container_name,
+            self.name_prefix + output_path, local_path)
+    
+    @backoff        
+    def exists(self, path):
+        """
+        Returns true if the given input or output file exists in Azure already.
+        
+        """
+        
+        self.__connect()
+        
+        marker = None
+        
+        while True:
+        
+            try:
+                # Make the container
+                self.connection.create_container(self.container_name)
+            except azure.WindowsAzureConflictError:
+                # The container probably already exists
+                pass
+            
+            # Get the results from Azure.
+            result = self.connection.list_blobs(self.container_name, 
+                prefix=self.name_prefix + path, marker=marker)
+                
+            for blob in result:
+                # Look at each blob
+                
+                if blob.name == self.name_prefix + path:
+                    # Found it
+                    return True
+                
+            # Save the marker
+            marker = result.next_marker
+                
+            if not marker:
+                break 
+        
+        return False
+        
+        
+    @backoff        
+    def get_mtime(self, path):
+        """
+        Returns the modification time of the given blob if it exists, or None
+        otherwise.
+        
+        """
+       
+        raise NotImplementedError()
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -16,7 +16,7 @@ import posixpath
 from bd2k.util.iterables import concat
 from boto.s3.connection import S3Connection, Bucket
 from boto.s3.key import Key
-from toil_lib.toillib import IOStore
+from toil_vg.iostore import IOStore
 
 log = logging.getLogger(__name__)
 

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -14,7 +14,7 @@ import getpass
 import pdb
 import textwrap
 import yaml
-from toil_lib import require
+from toil_vg.vg_common import require
 
 # TODO: configure RPATH-equivalent on OS X for finding libraries without environment variables at runtime
 def generate_config():

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -114,6 +114,9 @@ def generate_config():
         ##########################
         ### vg_index Arguments ###
 
+        # Name of index output files.  ex <name>.xg, <name>.gcsa etc. 
+        index-name: 'genome'
+
         # Options to pass to vg mod for pruning phase. (if empty list, phase skipped)
         # The primary path will always be added back onto the pruned grpah
         prune-opts: ['-p', '-l', '16', '-S', '-e', '5']

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -52,6 +52,9 @@ def index_parse_args(parser):
     parser.add_argument("--index_cores", type=int,
         help="number of threads during the indexing step")
 
+    parser.add_argument("--index_name", type=str,
+                        help="name of index files. <name>.xg, <name>.gcsa etc.")
+
 def run_gcsa_kmers(job, options, graph_i, input_graph_id):
     """
     Make the kmers file, return its id
@@ -158,7 +161,7 @@ def run_gcsa_indexing(job, options, kmers_ids):
         kmers_filenames.append(kmers_filename)
 
     # Where do we put the GCSA2 index?
-    gcsa_filename = "genome.gcsa"
+    gcsa_filename = "{}.gcsa".format(options.index_name)
 
     command = ['vg', 'index', '-g', os.path.basename(gcsa_filename)] + options.gcsa_opts
     command += ['-t', str(job.cores)]
@@ -199,7 +202,7 @@ def run_xg_indexing(job, options, inputGraphFileIDs):
         graph_filenames.append(os.path.basename(graph_filename))
 
     # Where do we put the XG index?
-    xg_filename = "genome.xg"
+    xg_filename = "{}.xg".format(options.index_name)
 
     # Now run the indexer.
     RealtimeLogger.info("XG Indexing {}".format(str(graph_filenames)))            

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -18,9 +18,8 @@ from Bio import SeqIO
 
 from toil.common import Toil
 from toil.job import Job
-from toil_lib.toillib import *
+from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
-from toil_lib import require
 
 def index_subparser(parser):
     """
@@ -57,7 +56,7 @@ def run_gcsa_kmers(job, options, graph_i, input_graph_id):
     """
     Make the kmers file, return its id
     """
-    RealTimeLogger.get().info("Starting gcsa kmers...")
+    RealtimeLogger.info("Starting gcsa kmers...")
     start_time = timeit.default_timer()
 
     # Define work directory for docker calls
@@ -84,25 +83,25 @@ def run_gcsa_kmers(job, options, graph_i, input_graph_id):
             if len(options.prune_opts_2) > 0:
                 command = [command]
                 command.append(['vg', 'mod', '-', '-t', str(job.cores)] + options.prune_opts_2)
-            options.drunner.call(command, work_dir=work_dir, outfile=to_index_file)
+            options.drunner.call(job, command, work_dir=work_dir, outfile=to_index_file)
             
             # Then append in the primary path.
             command = ['vg', 'mod', '-N', '-r', options.chroms[graph_i]]
             command += ['-t', str(job.cores), os.path.basename(graph_filename)]
-            options.drunner.call(command, work_dir=work_dir, outfile=to_index_file)
+            options.drunner.call(job, command, work_dir=work_dir, outfile=to_index_file)
 
     time.sleep(1)
     
     # Now we have the combined to-index graph in one vg file. We'll load
     # it (which deduplicates nodes/edges) and then find kmers.
-    RealTimeLogger.get().info("Finding kmers in {} to {}".format(
+    RealtimeLogger.info("Finding kmers in {} to {}".format(
         to_index_filename, output_kmers_filename))
 
     # Make the GCSA2 kmers file
     with open(output_kmers_filename, "w") as kmers_file:
         command = ['vg', 'kmers',  os.path.basename(to_index_filename), '-t', str(job.cores)]
         command += options.kmers_opts
-        options.drunner.call(command, work_dir=work_dir, outfile=kmers_file)
+        options.drunner.call(job, command, work_dir=work_dir, outfile=kmers_file)
 
     # Dont' need to keep pruned graph around after kmers computed.
     if to_index_filename != graph_filename:
@@ -113,7 +112,7 @@ def run_gcsa_kmers(job, options, graph_i, input_graph_id):
 
     end_time = timeit.default_timer()
     run_time = end_time - start_time
-    RealTimeLogger.get().info("Finished GCSA kmers. Process took {} seconds.".format(run_time))
+    RealtimeLogger.info("Finished GCSA kmers. Process took {} seconds.".format(run_time))
 
     return output_kmers_id
 
@@ -122,7 +121,7 @@ def run_gcsa_prep(job, options, input_graph_ids):
     Do all the preprocessing for gcsa indexing (pruning and kmers)
     Then launch the indexing as follow-on
     """    
-    RealTimeLogger.get().info("Starting gcsa preprocessing...")
+    RealtimeLogger.info("Starting gcsa preprocessing...")
     start_time = timeit.default_timer()     
 
     kmers_ids = []
@@ -144,7 +143,7 @@ def run_gcsa_indexing(job, options, kmers_ids):
     Make the gcsa2 index. Return its store id
     """
     
-    RealTimeLogger.get().info("Starting gcsa indexing...")
+    RealtimeLogger.info("Starting gcsa indexing...")
     start_time = timeit.default_timer()     
 
     # Define work directory for docker calls
@@ -165,7 +164,7 @@ def run_gcsa_indexing(job, options, kmers_ids):
     command += ['-t', str(job.cores)]
     for kmers_filename in kmers_filenames:
         command += ['-i', os.path.basename(kmers_filename)]
-    options.drunner.call(command, work_dir=work_dir)
+    options.drunner.call(job, command, work_dir=work_dir)
 
     # Checkpoint index to output store
     if not options.force_outstore or options.tool == 'index':
@@ -180,13 +179,13 @@ def run_gcsa_indexing(job, options, kmers_ids):
 
     end_time = timeit.default_timer()
     run_time = end_time - start_time
-    RealTimeLogger.get().info("Finished GCSA index. Process took {} seconds.".format(run_time))
+    RealtimeLogger.info("Finished GCSA index. Process took {} seconds.".format(run_time))
 
 def run_xg_indexing(job, options, inputGraphFileIDs):
     """ Make the xg index and return its store id
     """
     
-    RealTimeLogger.get().info("Starting xg indexing...")
+    RealtimeLogger.info("Starting xg indexing...")
     start_time = timeit.default_timer()
     
     # Define work directory for docker calls
@@ -200,15 +199,15 @@ def run_xg_indexing(job, options, inputGraphFileIDs):
         graph_filenames.append(os.path.basename(graph_filename))
 
     # Where do we put the XG index?
-    xg_filename = graph_filename + ".xg"
+    xg_filename = "genome.xg"
 
     # Now run the indexer.
-    RealTimeLogger.get().info("XG Indexing {}".format(str(graph_filenames)))            
+    RealtimeLogger.info("XG Indexing {}".format(str(graph_filenames)))            
 
     command = ['vg', 'index', '-t', str(job.cores), '-x', os.path.basename(xg_filename)]
     command += graph_filenames
     
-    options.drunner.call(command, work_dir=work_dir)
+    options.drunner.call(job, command, work_dir=work_dir)
 
     # Checkpoint index to output store
     if not options.force_outstore or options.tool == 'index':
@@ -221,7 +220,7 @@ def run_xg_indexing(job, options, inputGraphFileIDs):
 
     end_time = timeit.default_timer()
     run_time = end_time - start_time
-    RealTimeLogger.get().info("Finished XG index. Process took {} seconds.".format(run_time))
+    RealtimeLogger.info("Finished XG index. Process took {} seconds.".format(run_time))
 
     
 
@@ -242,8 +241,6 @@ def index_main(options):
     Wrapper for vg indexing. 
     """
     
-    RealTimeLogger.start_master()
-
     # make the docker runner
     options.drunner = DockerRunner(
         docker_tool_map = get_docker_tool_map(options))
@@ -288,5 +285,3 @@ def index_main(options):
  
     print("All jobs completed successfully. Pipeline took {} seconds.".format(run_time_pipeline))
     
-    RealTimeLogger.stop_master()
-

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 
 from toil.common import Toil
 from toil.job import Job
-from toil_lib.toillib import *
 from toil_vg.vg_common import *
 
 def vcfeval_subparser(parser):
@@ -158,8 +157,6 @@ def run_vcfeval(job, options,
 def vcfeval_main(options):
     """ command line access to toil vcf eval logic"""
     
-    RealTimeLogger.start_master()
-
     # make the docker runner
     options.drunner = DockerRunner(
         docker_tool_map = dict(get_docker_tool_map(options).items() +
@@ -209,7 +206,5 @@ def vcfeval_main(options):
     run_time_pipeline = end_time_pipeline - start_time_pipeline
  
     print("All jobs completed successfully. Pipeline took {} seconds.".format(run_time_pipeline))
-    
-    RealTimeLogger.stop_master()
     
     

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -71,7 +71,7 @@ def get_vcfeval_docker_tool_map(options):
     return dmap
     
     
-def vcfeval(work_dir, call_vcf_name, truth_vcf_name,
+def vcfeval(job, work_dir, call_vcf_name, truth_vcf_name,
             sdf_name, outdir_name, bed_name, options):
 
     """ create and run the vcfeval command """
@@ -87,7 +87,7 @@ def vcfeval(work_dir, call_vcf_name, truth_vcf_name,
     if len(options.vcfeval_filtering_opts) > 0:
         cmd += options.vcfeval_filtering_opts.split()
 
-    options.drunner.call(cmd, work_dir=work_dir)
+    options.drunner.call(job, cmd, work_dir=work_dir)
 
     # get the F1 out of summary.txt
     # expect header on 1st line and data on 3rd
@@ -138,10 +138,10 @@ def run_vcfeval(job, options,
             bed_name = os.path.join('/data', bed_name)
 
     # make an indexed sequence (todo: allow user to pass one in)
-    options.drunner.call(['rtg', 'format',  fasta_name, '-o', sdf_name], work_dir=work_dir)    
+    options.drunner.call(job, ['rtg', 'format',  fasta_name, '-o', sdf_name], work_dir=work_dir)    
 
     # run the vcf_eval command
-    f1 = vcfeval(work_dir, call_vcf_name, truth_vcf_name,
+    f1 = vcfeval(job, work_dir, call_vcf_name, truth_vcf_name,
                  sdf_name, out_name, bed_name, options)
 
     # todo : write everything to output store.

--- a/version.py
+++ b/version.py
@@ -14,10 +14,10 @@
 
 version = '1.1.0a1'
 
-required_versions = {'toil': '==3.5.0a1.dev251',
-                     'toil-lib': '==1.1.0a1',
-                     'pyyaml': '==3.11',
-                     'biopython': '==1.67',
-                     'pyvcf': '==0.6.8'}
+required_versions = {'toil': '>=3.5.0a1.dev251',
+                     'pyyaml': '>=3.11',
+                     'biopython': '>=1.67',
+                     'pyvcf': '>=0.6.8',
+                     'boto3': '>=1.4.4'}
 
-dependency_links = ['git+https://github.com/cmarkello/toil-lib.git#egg=toil-lib-1.1.0a1']
+dependency_links = []


### PR DESCRIPTION
https://github.com/cmarkello/toil-lib has served its purpose, but it's duplicating lots of code from toil and has diverged pretty far from the bd2kgenomics toil-lib.  These are the parts of toil-lib that toil-vg used, and what's been done in this PR

* RealtimeLogger
    - Switch to Toil's realtimeLogger
* IOStore
    - Move IOStore class into toil-vg/iostore.py for now.  Can either push up to main toil_lib or replace with Toil's job file store.  I tried the latter here https://github.com/glennhickey/toil-vg/tree/issues/110-fix-iostore, but couldn't get Toil's S3 jobstore to be robust for big transfers. 
* docker_call
    - Move docker call into vg_common.py.  Will PR this version into mainline toil and remove from toil-vg whenever it gets merged. 

