### PR TITLE
Integrate vcfeval into pipeline

### DIFF
--- a/bakeoff.sh
+++ b/bakeoff.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+## TODO: Get this going in some sort of CI framework
+##       Ideally:  vg merge to master triggers docker build then a run of this script
+##                 with the accuracy results logged to some kind of persistent leaderboard
+##
+## For now, all we have is the basic logic to do one run of bakeoff, expecting
+## virtualenv etc has already been set up. 
+
+if [ "$#" -ne 2 ]; then
+	 echo "Syntax $0 <MESOS> <F1FILE>"
+	 echo "(MESOS = [0,1])"
+	 exit 1
+fi
+
+# all input data expected to be here:
+BAKEOFF_STORE="s3://glennhickey-bakeoff-store"
+
+# set to 1 to toggle mesos / s3
+MESOS=$1
+F1FILE=$2
+
+# General Options
+OPTS='--index_cores 7 --alignment_cores 7 --calling_cores 7 --vcfeval_cores 7 --realTimeLogging --logInfo'
+
+# Hack in support for switching between mesos and local here
+# (Note, for job store and out store, we will tack on -REGION to make them unique)
+if [ "$MESOS" == "1" ]; then
+	 JOB_STORE="$aws:us-west-2:glennhickey-bakeoff-job-store"
+	 OUT_STORE="$aws:us-west-2:glennhickey-bakeoff-out-store"
+	 CP_OUT_STORE="s3://glennhickey-bakeoff-out-store"
+	 BS_OPTS="--batchSystem=mesos --mesosMaster=mesos-master:5050"
+	 CP_CMD="aws s3 cp"
+	 RM_CMD="aws s3 rm"
+else
+	 JOB_STORE="./bakeoff-job-store"
+	 OUT_STORE="./bakeoff-out-store"
+	 CP_OUT_STORE=${OUT_STORE}
+	 BS_OPTS=""
+	 CP_CMD="cp"
+	 RM_CMD="rm"
+fi
+
+# Run toil-vg on a bakeoff region
+function run_bakeoff_region {
+	 local REGION=$1
+	 local CHROM=$2
+	 local OFFSET=$3
+
+	 # erase the job store and f1 output
+	 toil clean ${JOB_STORE}-${REGION}
+	 F1_SCORE="${CP_OUT_STORE}-${REGION}/NA12878_vcfeval_output_f1.txt"
+	 $RM_CMD $F1_SCORE
+
+	 # run the whole pipeline
+	 toil-vg run ${JOB_STORE}-${REGION} ${BAKEOFF_STORE}/platinum_NA12878_${REGION}.fq.gz NA12878 ${OUT_STORE}-${REGION} --chroms ${CHROM} --call_opts "--offset ${OFFSET}" --graphs ${BAKEOFF_STORE}/snp1kg-${REGION}.vg --vcfeval_baseline ${BAKEOFF_STORE}/platinum_NA12878_${REGION}.vcf.gz --vcfeval_fasta ${BAKEOFF_STORE}/chrom.fa.gz ${BS_OPTS} ${OPTS}
+
+	 # harvest the f1 output and append it to our table
+	 rm -f temp_f1.txt
+	 $CP_CMD $F1_SCORE ./temp_f1.txt
+	 if [ -f "./temp_f1.txt" ] ; then
+		  printf "${REGION}\t$(cat ./temp_f1.txt)\n" >> ${F1FILE}
+	 else
+		  printf "${REGION}\tERROR\n" >> ${F1FILE}
+	 fi
+}
+
+# Run the regions in series
+
+rm -f $F1FILE
+
+run_bakeoff_region BRCA1 17 43044293
+run_bakeoff_region BRCA2 13 32314860
+run_bakeoff_region SMA 5 692168181
+run_bakeoff_region LRC_KIR 9 54025633
+run_bakeoff_region MHC 6 28510119
+
+
+        

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -50,6 +50,7 @@ def get_docker_tool_map(options):
         dmap["tabix"] = options.tabix_docker
         dmap["bgzip"] = options.tabix_docker
         dmap["jq"] = options.jq_docker
+        dmap["rtg"] = options.rtg_docker
 
     # to do: could be a good place to do an existence check on these tools
 

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -86,6 +86,11 @@ def generate_config():
         calling-mem: '4G'
         calling-disk: '2G'
 
+        # Resources for vcfeval
+        vcfeval-cores: 1
+        vcfeval-mem: '4G'
+        vcfeval-disk: '2G'
+
         ###########################################
         ### Arguments Shared Between Components ###
         # Use output store instead of toil for all intermediate files (use only for debugging)
@@ -181,6 +186,14 @@ def generate_config():
 
         # Use vg genotype instead of vg call
         genotype: False
+
+        #########################
+        ### vcfeval Arguments ###
+        # Options to pass to rgt vcfeval. (do not include filenaems or threads or BED)
+        vcfeval-opts: []
+
+        # BED region file for vcfeval
+        vcfeval-bed-regions:
         
     """)
 

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -66,7 +66,7 @@ def map_parse_args(parser, stand_alone = False):
         help="type of vg index to use for mapping")
     parser.add_argument("--interleaved", action="store_true", default=False,
                         help="treat fastq as interleaved read pairs.  overrides map-args")
-    parser.add_argument("--map-opts", type=str,
+    parser.add_argument("--map_opts", type=str,
                         help="arguments for vg map (wrapped in \"\")")
 
 def run_mapping(job, options, xg_file_id, gcsa_and_lcp_ids, reads_file_id):


### PR DESCRIPTION
* Compute VCF comparison as part of toil-vg run if baseline information options used
* Rejig the unit tests to use this interface
* Add bakeoff.sh script to make a table of F1 scores for the bakeoff regions.  Still work to be done here in terms of deploying properly. 