### PR TITLE
Faster gam split

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -114,7 +114,7 @@ def generate_config():
         ##   of through docker. no-docker (above) overrides all these options. 
 
         # Docker container to use for vg
-        vg-docker: ['quay.io/glennhickey/vg:v1.4.0-2134-g161bec5', True]
+        vg-docker: ['quay.io/glennhickey/vg:v1.4.0-2213-gdce81f8', True]
 
         # Docker container to use for bcftools
         bcftools-docker: ['quay.io/cmarkello/bcftools', False]


### PR DESCRIPTION
Dividing the output of vg map into chromosomes was taking forever, and using a ton of memory (#119).  Address with these changes
* Determine node range for each input chromosome in vg index
* Use this node range to split gams in vg chunk, without ever extracting subgraphs. 
We maintain the path-based subgraph extraction when splitting gams into small chunks for vg call, where it doesn't seem to harm much and, more importantly, where we don't want to enforce a node range guarantee.  