### PR TITLE
Pass multiple gams to toil-vg call

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 `toil-vg index`: Produce an index from input graph(s).
 
-`toil-vg map`: Produce graph alignment (gam) from input reads and index
+`toil-vg map`: Produce graph alignment (gam) for each chromosome from input reads and index
 
-`toil-vg call`: Produce VCF from input index and alignment (for single chromosome)
+`toil-vg call`: Produce VCF from input index and chromosome gam(s)
 
 ## Installation
 
@@ -165,7 +165,7 @@ Terminate the cluster
 
 This part of the pipeline is more distributed, so we make a larger cluster with less storage.  Note: indexing, mapping, and calling can be done in a single invocation of `toil-vg run` (by leaving out `--gcsa_index`, `--xg_index`, and `--id_ranges`) if you feel your setup is up to it.   
 
-    cglcoud create-cluster toil -s 8 --instance-type r3.8xlarge  --leader-instance-type r3.2xlarge --cluster-name toil-map-cluster
+    cgcloud create-cluster toil -s 8 --instance-type r3.8xlarge  --leader-instance-type r3.2xlarge --cluster-name toil-map-cluster
     cgcloud ssh --admin -c toil-map-cluster toil-leader 'sudo apt-get install -y aria2'    
     cgcloud ssh-cluster --admin --cluster-name toil-map-cluster toil 'sudo pip install toil-vg'
 

--- a/bakeoff.sh
+++ b/bakeoff.sh
@@ -74,7 +74,7 @@ function run_bakeoff_region {
 	 # run the whole pipeline
 	 toil-vg run ${JOB_STORE}-${REGION,,} ${BAKEOFF_STORE}/platinum_NA12878_${REGION}.fq.gz NA12878 ${OUT_STORE}-${REGION,,} --chroms ${CHROM} --call_opts "--offset ${OFFSET}" --graphs ${BAKEOFF_STORE}/snp1kg-${REGION}.vg --vcfeval_baseline ${BAKEOFF_STORE}/platinum_NA12878_${REGION}.vcf.gz --vcfeval_fasta ${BAKEOFF_STORE}/chrom.fa.gz ${BS_OPTS} ${OPTS}
 
-	 toil-vg clean ${JOB_STORE}-${REGION,,}
+	 toil clean ${JOB_STORE}-${REGION,,}
 
 	 # harvest the f1 output and append it to our table
 	 rm -f temp_f1.txt

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -46,26 +46,22 @@ misc-disk: '1G'
 
 # Resources allotted for xg indexing.
 # this stage generally cannot take advantage of more than one thread
-# For whole genome, suggest 200G mem and disk
 xg-index-cores: 1
 xg-index-mem: '4G'
 xg-index-disk: '2G'
 
 # Resources allotted for gcsa pruning.  Note that the vg mod commands used in
 # this stage generally cannot take advantage of more than one thread
-# For whole genome, suggest 60G mem and disk
 prune-cores: 1
 prune-mem: '4G'
 prune-disk: '2G'
 
 # Resources allotted for gcsa kmers.  
-# For whole genome, suggest 70G mem and disk
 kmers-cores: 1
 kmers-mem: '4G'
 kmers-disk: '2G'
 
 # Resources allotted gcsa indexing
-# For whole genome, suggest 200G mem and 3T disk
 gcsa-index-cores: 1
 gcsa-index-mem: '4G'
 gcsa-index-disk: '2G'
@@ -83,7 +79,6 @@ gam-index-cores: 1
 
 # Resources for *each* vg map job
 # the number of vg map jobs is controlled by reads-per-chunk (below)
-# For whole genome, suggest 100G memory and disk for whole genome
 alignment-cores: 1
 alignment-mem: '4G'
 alignment-disk: '2G'
@@ -91,13 +86,11 @@ alignment-disk: '2G'
 # Resources for chunking up a graph/gam for calling (and merging)
 # typically take xg for whoe grpah, and gam for a chromosome,
 # and split up into chunks of call-chunk-size (below)
-# For whole genome, suggest 20G memory and 100G disk
 call-chunk-cores: 1
 call-chunk-mem: '4G'
 call-chunk-disk: '2G'
 
 # Resources for calling each chunk (currently includes pileup/call/genotype)
-# For whole genome, suggest 20G memory and 20G disk
 calling-cores: 1
 calling-mem: '4G'
 calling-disk: '2G'
@@ -246,26 +239,22 @@ misc-disk: '1G'
 
 # Resources allotted for xg indexing.
 # this stage generally cannot take advantage of more than one thread
-# For whole genome, suggest 200G mem and disk
 xg-index-cores: 1
 xg-index-mem: '200G'
 xg-index-disk: '200G'
 
 # Resources allotted for gcsa pruning.  Note that the vg mod commands used in
 # this stage generally cannot take advantage of more than one thread
-# For whole genome, suggest 60G mem and disk
 prune-cores: 2
 prune-mem: '60G'
 prune-disk: '60G'
 
 # Resources allotted for gcsa kmers.  
-# For whole genome, suggest 70G mem and disk
 kmers-cores: 16
 kmers-mem: '70G'
 kmers-disk: '60G'
 
 # Resources allotted gcsa indexing
-# For whole genome, suggest 200G mem and 3T disk
 gcsa-index-cores: 32
 gcsa-index-mem: '200G'
 gcsa-index-disk: '3000G'
@@ -283,7 +272,6 @@ gam-index-cores: 6
 
 # Resources for *each* vg map job
 # the number of vg map jobs is controlled by reads-per-chunk (below)
-# For whole genome, suggest 100G memory and disk for whole genome
 alignment-cores: 32
 alignment-mem: '100G'
 alignment-disk: '100G'
@@ -291,15 +279,13 @@ alignment-disk: '100G'
 # Resources for chunking up a graph/gam for calling (and merging)
 # typically take xg for whoe grpah, and gam for a chromosome,
 # and split up into chunks of call-chunk-size (below)
-# For whole genome, suggest 20G memory and 100G disk
-call-chunk-cores: 2
-call-chunk-mem: '20G'
+call-chunk-cores: 8
+call-chunk-mem: '64G'
 call-chunk-disk: '100G'
 
 # Resources for calling each chunk (currently includes pileup/call/genotype)
-# For whole genome, suggest 20G memory and 20G disk
-calling-cores: 32
-calling-mem: '32G'
+calling-cores: 8
+calling-mem: '60G'
 calling-disk: '32G'
 
 # Resources for vcfeval

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -34,7 +34,7 @@ def index_subparser(parser):
     
     # General options
     parser.add_argument("out_store",
-        help="output IOStore to create and fill with files that will be downloaded to the local machine where this toil script was run")
+        help="output store.  All output written here. Path specified using same syntax as toil jobStore")
 
     # Add common options shared with everybody
     add_common_vg_parse_args(parser)

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -44,9 +44,9 @@ def map_subparser(parser):
         help="Path to GCSA index")
     parser.add_argument("id_ranges", type=str,
         help="Path to file with node id ranges for each chromosome in BED format.  If not"
-                            " supplied, will be generated from --graphs)")        
+                            " supplied, will be generated from --graphs)")
     parser.add_argument("out_store",
-        help="output IOStore to create and fill with files that will be downloaded to the local machine where this toil script was run")
+        help="output store.  All output written here. Path specified using same syntax as toil jobStore")
     parser.add_argument("--kmer_size", type=int,
         help="size of kmers to use in indexing and mapping")
 

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -31,8 +31,8 @@ def vcfeval_subparser(parser):
     parser.add_argument("vcfeval_fasta", type=str,
                         help="fasta file containing the DNA sequence.  Can be"
                         " gzipped with .gz extension")
-    parser.add_argument("out_store", type=str,
-                        help="vcfeval output store")
+    parser.add_argument("out_store",
+                            help="output store.  All output written here. Path specified using same syntax as toil jobStore")
 
     # Add common options shared with everybody
     add_common_vg_parse_args(parser)
@@ -84,12 +84,14 @@ def vcfeval(job, work_dir, call_vcf_name, vcfeval_baseline_name,
         assert len(data) == len(header)
         return float(data[-1])    
     
-def run_vcfeval(job, options, vcfeval_baseline_id, vcfeval_baseline_tbi_id, call_vcf_id, call_tbi_id,
+def run_vcfeval(job, options, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeval_baseline_tbi_id, 
                 fasta_id, bed_id):                
     """ run vcf_eval, return f1 score """
 
     # make a local work directory
     work_dir = job.fileStore.getLocalTempDir()
+
+    call_vcf_id, call_tbi_id = vcf_tbi_id_pair[0], vcf_tbi_id_pair[1]
 
     vcfeval_baseline_name = "truth_" + os.path.basename(options.vcfeval_baseline)
     call_vcf_name = "calls.vcf.gz"


### PR DESCRIPTION
This makes toil-vg call more consistent with other tools, in that it can be used directly on the output of toil-vg map, or the gam output of toil-vg run.  