### PR TITLE
remove --no_docker from readme and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install Docker via instructions found [here](https://docs.docker.com/docker-for-
     eval "$(docker-machine env default)"
     
 #### Running without Docker
-It can be useful, especially for developers to run commands directly without docker.  This can be done by using the `--no_docker` flag when running toil-vg, but all command-line tools (vg, bcftools, samtools, etc) must all be runnable from the command line.  
+It can be useful, especially for developers to run commands directly without docker.  This can be done by using the `--container None` option when running toil-vg, but all command-line tools (vg, bcftools, samtools, etc) must be available on the command line.  
 
 
 ## Configuration

--- a/bakeoff.sh
+++ b/bakeoff.sh
@@ -87,7 +87,7 @@ fi
 
 # Hack in support for turning Docker on and off
 if [ "$DOCKER" == "0" ]; then
-    DOCKER_OPTS="--no_docker"
+    DOCKER_OPTS="--container None"
 else
     DOCKER_OPTS=""
 fi

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 def add_container_tool_parse_args(parser):
     """ centralize shared container options and their defaults """
     
-    parser.add_argument("--container", default='docker', choices=['docker', 'singularity', 'none'],
-                       help="Container type used for running commands. Use none to "
+    parser.add_argument("--container", default=None, choices=['Docker', 'Singularity', 'None'],
+                       help="Container type used for running commands. Use None to "
                        " run locally on command line")    
 
 def add_common_vg_parse_args(parser):
@@ -42,7 +42,7 @@ def get_container_tool_map(options):
     smap = dict()
     # first check for docker use, if docker use is not desired then check
     # for singularity use
-    if options.container == 'docker':
+    if options.container == 'Docker':
         dmap["vg"] = options.vg_docker
         dmap["bcftools"] = options.bcftools_docker
         dmap["tabix"] = options.tabix_docker
@@ -52,7 +52,7 @@ def get_container_tool_map(options):
         dmap["pigz"] = options.pigz_docker
         dmap["samtools"] = options.samtools_docker
         dmap["bwa"] = options.bwa_docker
-    elif options.container == 'singularity':
+    elif options.container == 'Singularity':
         smap["vg"] = options.vg_singularity
         smap["bcftools"] = options.bcftools_singularity
         smap["tabix"] = options.tabix_singularity

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -110,16 +110,18 @@ sim-disk: '2G'
 # Use output store instead of toil for all intermediate files (use only for debugging)
 force-outstore: False
 
+# Toggle container support.  Valid values are Docker / Singularity / None
+# (commenting out or Null values equivalent to None)
+container: Docker
+
 #############################
 ### Docker Tool Arguments ###
-# Do not use docker for any commands
-no-docker: False
 
 ## Docker Tool List ##
 ##   Each tool is specified as a list where the first element is the docker image URL,
 ##   and the second element indicates if the docker image has an entrypoint or not
 ##   If left blank or commented, then the tool will be run directly from the command line instead
-##   of through docker. no-docker (above) overrides all these options. 
+##   of through docker. 
 
 # Docker container to use for vg
 vg-docker: ['quay.io/vgteam/vg:v1.5.0-0-g6ef422a9-t41-run', False]
@@ -147,15 +149,12 @@ pigz-docker: ['quay.io/glennhickey/pigz:latest', True]
 
 #############################
 ### Singularity Tool Arguments ###
-# Do not use singularity for any commands
-no-singularity: False
 
 ## Singularity Tool List ##
 ##   Each tool is specified as a list where the first element is the PATH on a shared filesystem
 ##   where the singularity image lies.
 ##   If left blank or commented, then the tool will be run directly from the command line instead
-##   of through singularity. no-singularity (above) overrides all these options. 
-##   Note: no-singuarity and no-docker options can't both be set to True.
+##   of through singularity.
 
 # Singularity container to use for vg
 vg-singularity: ['', True]
@@ -358,16 +357,18 @@ sim-disk: '2G'
 # Use output store instead of toil for all intermediate files (use only for debugging)
 force-outstore: False
 
+# Toggle container support.  Valid values are Docker / Singularity / None
+# (commenting out or Null values equivalent to None)
+container: Docker
+
 #############################
 ### Docker Tool Arguments ###
-# Do not use docker for any commands
-no-docker: False
 
 ## Docker Tool List ##
 ##   Each tool is specified as a list where the first element is the docker image URL,
 ##   and the second element indicates if the docker image has an entrypoint or not
 ##   If left blank or commented, then the tool will be run directly from the command line instead
-##   of through docker. no-docker (above) overrides all these options. 
+##   of through docker. 
 
 # Docker container to use for vg
 vg-docker: ['quay.io/vgteam/vg:v1.5.0-0-g6ef422a9-t41-run', False]
@@ -395,15 +396,12 @@ pigz-docker: ['quay.io/glennhickey/pigz:latest', True]
 
 #############################
 ### Singularity Tool Arguments ###
-# Do not use singularity for any commands
-no-singularity: False
 
 ## Singularity Tool List ##
 ##   Each tool is specified as a list where the first element is the PATH on a shared filesystem
 ##   where the singularity image lies.
 ##   If left blank or commented, then the tool will be run directly from the command line instead
-##   of through singularity. no-singularity (above) overrides all these options. 
-##   Note: no-singuarity and no-docker options can't both be set to True.
+##   of through singularity.
 
 # Singularity container to use for vg
 vg-singularity: ['', True]


### PR DESCRIPTION
Fix a few things forgotten in #164: Namely updating the README and confg to reflect the removal of --no_docker and --no_singularity options.  