### PR TITLE
Fix version import to be clever and always find the correct version.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 import sys
+import os
 
-from version import version, required_versions, dependency_links
+# We can't import version.py because only one "version" module can ever be
+# loaded in a Python process, and multiple setup.py scripts may have to run in
+# the same process.
+execfile(os.path.join(os.path.dirname(os.path.realpath(__file__)), "version.py"))
+
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 


### PR DESCRIPTION
When depending on toil-vg via a Github dependency link from a package that itself tries to `from version import version` in its `setup.py`, and using that package's `setup.py` to start the install, Python can get confused.

Basically, Python thinks the `version` module has already been loaded, and doesn't reload the `version.py` that would be found looking in this directory. Python supplies the version of the depending package instead of toil-vg's version during the install, which causes all sorts of trouble (including installing with a filename based on that version instead of the real version).

This PR instructs Python to just dump everything in the `version.py` next to this `setup.py` into global scope, and bypasses the module system entirely. Since there's no way to do a relative import in a script, this is possibly the best solution.