### PR TITLE
Add back removed IOStore functionality

### DIFF
--- a/bakeoff.sh
+++ b/bakeoff.sh
@@ -251,5 +251,5 @@ if [ "$FAST" != "1" ]; then
 		  echo ${OUT_STORE}-mhc-me-snp1kg
 	 fi
 fi
-
+echo "${F1FILE}"
         


### PR DESCRIPTION
The mtime functionality on some of the IOStores was partly dropped. Also, the Azure IOStore was listing files with the IOStore's prefix tacked on, which is incorrect.

This should add back the mtime functionality, and fix the Azure listing functionality, by pulling from my toillib.