### PR TITLE
Drop now-deleted -a option from vg pileup options

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -234,7 +234,7 @@ chunk_context: 50
 filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
-pileup-opts: ['-q', '10', '-a']
+pileup-opts: ['-q', '10']
 
 # Options to pass to vg call. (do not include file names or -t/--threads)
 call-opts: ['']


### PR DESCRIPTION
Glenn dropped this option, but toil-vg still wants to pass it, which makes the bakeoff script not work.

This is going to screw up your pileups unless you switch your VG containers to a build after today, or pass your own pileup options.