### PR TITLE
Fix defray filter in chunked calling

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -230,7 +230,7 @@ call-chunk-size: 10000000
 chunk_context: 50
 
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15']
+filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15', '-D', '999']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
 pileup-opts: ['-q', '10']
@@ -338,8 +338,8 @@ call-chunk-disk: '200G'
 
 # Resources for calling each chunk (currently includes pileup/call/genotype)
 calling-cores: 4
-calling-mem: '30G'
-calling-disk: '32G'
+calling-mem: '64G'
+calling-disk: '64G'
 
 # Resources for vcfeval
 vcfeval-cores: 32
@@ -467,17 +467,17 @@ index-mode: gcsa-mem
 #########################
 ### vg_call Arguments ###
 # Overlap option that is passed into make_chunks and call_chunk
-overlap: 2000
+overlap: 5000
 
 # Chunk size
-call-chunk-size: 8000000
+call-chunk-size: 10000000
 
 # Context expansion used for graph chunking
 chunk_context: 50
 
 
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15']
+filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15', '-D', '999']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
 pileup-opts: ['-q', '10']


### PR DESCRIPTION
Previously, xg indexes were created on the fly for vg chunks if vg filter needed to defray.  The problem is that the gam chunks could contain nodes that hang off of the vg/xg chunk, which causes xg crashes when trying to access them.  

This fix just passes through the whole-genome xg index instead of creating one for the chunk.  This will push up disk and memory requirements for call jobs, but hopefully not overall time if toil's cache is smart. 

If this proves too slow, then may have to look at alternatives like cutting out these nodes in vg chunk (but this seems like more of a time bottleneck risk) or silently ignoring them in vg filter.  