### PR TITLE
Optional chunking

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -111,13 +111,12 @@ class VGCGLTest(TestCase):
                   os.path.join(self.local_outstore, 'small.xg'),
                   os.path.join(self.local_outstore, 'small.gcsa'),
                   self.local_outstore,  '--fastq', self.sample_reads,
-                  '--id_ranges', os.path.join(self.local_outstore, 'small_id_ranges.tsv'),
                   '--alignment_cores', '8', '--reads_per_chunk', '8000',
                   '--realTimeLogging', '--logInfo')
         
         self._run('toil-vg', 'call', self.jobStoreLocal,
                   os.path.join(self.local_outstore, 'small.xg'), 'sample',
-                  self.local_outstore, '--gams', os.path.join(self.local_outstore, 'sample_x.gam'), 
+                  self.local_outstore, '--gams', os.path.join(self.local_outstore, 'sample_default.gam'), 
                   '--chroms', 'x', '--call_chunk_size', '20000', '--calling_cores', '4',
                   '--realTimeLogging', '--logInfo')
 
@@ -151,7 +150,6 @@ class VGCGLTest(TestCase):
                   os.path.join(self.local_outstore, 'small.gcsa'),
                   self.local_outstore,
                   '--gam_input_reads', os.path.join(self.local_outstore, 'sim.gam'),
-                  '--id_ranges', os.path.join(self.local_outstore, 'small_id_ranges.tsv'),
                   '--alignment_cores', '3', '--reads_per_chunk', '1000',
                   '--realTimeLogging', '--logInfo', '--interleaved')
 
@@ -162,7 +160,7 @@ class VGCGLTest(TestCase):
                   os.path.join(self.local_outstore, 'true.pos'),
                   '--index-bases', os.path.join(self.local_outstore, 'small'),
                   '--gam_input_reads', os.path.join(self.local_outstore, 'sim.gam'),
-                  '--gams', os.path.join(self.local_outstore, 'sample_x.gam'),
+                  '--gams', os.path.join(self.local_outstore, 'sample_default.gam'),
                   '--gam-names', 'vg', '--realTimeLogging', '--logInfo',
                   '--maxCores', '8', '--bwa', '--bwa-paired', '--fasta', self.chrom_fa)
 

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -242,6 +242,7 @@ class VGCGLTest(TestCase):
                   self.local_outstore, '--fastq', self.sample_reads, '--graphs',
                   self.test_vg_graph, self.test_vg_graph2, '--chroms', '17', '13',
                   '--vcf_offsets', '43044293', '32314860', '--interleaved',
+                  '--single_reads_chunk',
                   '--vcfeval_baseline', self.baseline, '--vcfeval_fasta', self.chrom_fa)
 
         self._assertOutput('NA12877', self.local_outstore, f1_threshold=0.70)

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -514,8 +514,6 @@ def run_calling(job, options, xg_file_id, alignment_file_id, path_names, vcf_off
                                                    memory=options.call_chunk_mem,
                                                    disk=options.call_chunk_disk).rv()
  
-    RealtimeLogger.info("Completed variant calling on path {} from alignment file {}".format(path_name, str(alignment_file_id)))
-
     return vcf_gz_tbi_file_id_pair
 
 
@@ -556,7 +554,9 @@ def merge_vcf_chunks(job, options, path_name, clip_file_ids):
     # Save merged vcf files to the job store
     vcf_gz_file_id = write_to_store(job, options, vcf_path+".gz")
     vcf_tbi_file_id = write_to_store(job, options, vcf_path+".gz.tbi")
-        
+
+    RealtimeLogger.info("Completed variant calling on path {}".format(path_name))
+
     return vcf_gz_file_id, vcf_tbi_file_id
     
 def call_main(options):

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -230,7 +230,7 @@ call-chunk-size: 10000000
 chunk_context: 50
 
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15']
+filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15', '-D', '999']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
 pileup-opts: ['-q', '10']
@@ -338,8 +338,8 @@ call-chunk-disk: '200G'
 
 # Resources for calling each chunk (currently includes pileup/call/genotype)
 calling-cores: 4
-calling-mem: '30G'
-calling-disk: '32G'
+calling-mem: '64G'
+calling-disk: '64G'
 
 # Resources for vcfeval
 vcfeval-cores: 32
@@ -467,17 +467,17 @@ index-mode: gcsa-mem
 #########################
 ### vg_call Arguments ###
 # Overlap option that is passed into make_chunks and call_chunk
-overlap: 2000
+overlap: 5000
 
 # Chunk size
-call-chunk-size: 8000000
+call-chunk-size: 10000000
 
 # Context expansion used for graph chunking
 chunk_context: 50
 
 
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15']
+filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15', '-D', '999']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
 pileup-opts: ['-q', '10']

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -203,7 +203,11 @@ gcsa-opts: ['-X', '3', '-Z', '3000']
 ########################
 ### vg_map Arguments ###
 
-# Number of reads per chunk to use when splitting up fastq.  
+# Toggle whether reads are split into chunks
+single-reads-chunk: False
+
+# Number of reads per chunk to use when splitting up fastq.
+# (only applies if single-reads-chunk is False)
 # Each chunk will correspond to a vg map job
 reads-per-chunk: 10000000
 
@@ -449,7 +453,11 @@ gcsa-opts: ['-X', '3', '-Z', '3000']
 ########################
 ### vg_map Arguments ###
 
-# Number of reads per chunk to use when splitting up fastq.  
+# Toggle whether reads are split into chunks
+single-reads-chunk: False
+
+# Number of reads per chunk to use when splitting up fastq.
+# (only applies if single-reads-chunk is False)
 # Each chunk will correspond to a vg map job
 reads-per-chunk: 50000000
 


### PR DESCRIPTION
There are three places where things get split into chunks:
* input reads (into mapping)
* output gams (from mapping)
* input graphs (into calling)

In each case, time and disk overhead can be significant.  This PR will try to fix toil-vg so that chunking happens only if it is needed, or at the very least, that it can be disabled with the right options.  