### PR TITLE
Disable make docker

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -31,7 +31,7 @@ export PATH=$PATH:${PWD}/bin
 make prepare
 make develop
 make test
-make docker
+#make docker
 #make test_docker
 make clean
 


### PR DESCRIPTION
Just noticed pypi isn't getting updated (again).  It looks like Jenkins is aborting before pypi gets updated because make docker is failing.  Disabling docker build until it works reliably and produces usable images (#154)

Preparing to unpack .../libssl1.0.0_1.0.2d-0ubuntu1.5_amd64.deb ...
Unpacking libssl1.0.0:amd64 (1.0.2d-0ubuntu1.5) ...
make[2]: *** [build] Error 2
make[2]: Leaving directory `/mnt/ephemeral/workspace/toil-vg/docker/1.12.3.docker'
/bin/sh: 1: cd: can't cd to 1.11.2.docker
/bin/sh: 1: cd: can't cd to 1.10.3.docker
/bin/sh: 1: cd: can't cd to 1.9.1.docker
/bin/sh: 1: cd: can't cd to 1.8.3.docker
/bin/sh: 1: cd: can't cd to 1.7.1.docker
/bin/sh: 1: cd: can't cd to 1.6.2.docker
make[1]: *** [runtime-container.DONE] Error 2
make[1]: Leaving directory `/mnt/ephemeral/workspace/toil-vg/docker'
make: *** [docker] Error 2
Finished: FAILURE
