### PR TITLE
bump version

### DIFF
--- a/version.py
+++ b/version.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '1.2.0a1'
+version = '1.2.1a1'
 
 required_versions = {'pyyaml': '>=3.11',
                      'boto3': '>=1.4.4',


### PR DESCRIPTION
pip install is stuck on 1.2.0 by default.  increase to 1.2.1 so latest build gets installed by default (i hope)