### PR TITLE
Adjust default filter options

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -123,7 +123,7 @@ container: Docker
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-448-gcf6e6a74-t63-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-499-ge8a9bcbc-t64-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'quay.io/cmarkello/bcftools'
@@ -373,7 +373,7 @@ container: Docker
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-448-gcf6e6a74-t63-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-499-ge8a9bcbc-t64-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'quay.io/cmarkello/bcftools'

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -234,7 +234,7 @@ call-chunk-size: 10000000
 chunk_context: 50
 
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15', '-D', '999']
+filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '999']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
 pileup-opts: ['-q', '10']
@@ -485,7 +485,7 @@ chunk_context: 50
 
 
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15', '-D', '999']
+filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '999']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
 pileup-opts: ['-q', '10']

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -266,7 +266,7 @@ def run_chunk_alignment(job, options, chunk_filename_ids, chunk_id, xg_file_id, 
 
         # Plan out what to run
         vg_parts = []
-        vg_parts += ['vg', 'map',  os.path.basename(graph_file), '-t', str(options.alignment_cores)]
+        vg_parts += ['vg', 'map', '-t', str(options.alignment_cores)]
         for reads_file in reads_files:
             input_flag = '-G' if options.gam_input_reads else '-f'
             vg_parts += [input_flag, os.path.basename(reads_file)]


### PR DESCRIPTION
use -m 1 instead of -o 0, as it works better with vg's wonky softclip bonus (which is on by default in vg map).  

also don't pass .vg file to vg map is it's not needed. 