### PR TITLE
Add a read score comparison function to toil-vg mapeval

### DIFF
--- a/version.py
+++ b/version.py
@@ -16,6 +16,7 @@ version = '1.2.1a1'
 
 required_versions = {'pyyaml': '>=3.11',
                      'boto3': '>=1.4.4',
-                     'awscli': '>=1.10.1'}
+                     'awscli': '>=1.10.1',
+                     'tsv': '==1.2'}
 
 dependency_links = []


### PR DESCRIPTION
Now you can compare all the scores from aligning to GAMs against a baseline graph, and get out the differences and what portion of reads score worse than the baseline.

The code is kind of messy, because I pulled in a real TSV library but haven't replaced all the hand-code TSV stuff yet, and because I still need to pull in samtools to parse BWA scores from tags (so all BWA alignments pretend to have a score of 0 and aren't used in score comparisons yet). But I want to get it merged in so we can start bounding the fraction of reads that get worse in the Jenkins tests for vg.