### PR TITLE
Refactor initialization

### DIFF
--- a/src/toil_vg/context.py
+++ b/src/toil_vg/context.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python2.7
+"""
+context.py: Defines a toil_vg context, which contains (and hides) all the config
+file values, IOStore dumping parameters, and other things that need to be passed
+around but that toil-vg users shouldn't generally need to dinker with.
+
+Instead of dropping the container runner into the command-line options
+namespace, we keep them both in here.
+
+"""
+
+import tempfile
+import datetime
+import pkg_resources
+
+from argparse import Namespace
+from toil_vg.vg_config import apply_config_file_args
+from toil_vg.vg_common import ContainerRunner, get_container_tool_map
+from toil_vg.iostore import IOStore
+
+class Context(object):
+    """
+    Represents a toil-vg context, necessary to use the library.
+    """
+    
+    def __init__(self, out_store=None, overrides=Namespace()):
+        """
+        Make a new context, so we can run the library.
+        
+        Takes an optional Namespace of overrides for default toil-vg
+        configuration values.
+        
+        Overrides can also have a "config" key, in which case that config file
+        will be loaded.
+        
+        """
+        
+        # Load configuration and apply overrides. If the overrides are from
+        # command-line options, we might also get a bunch of tool-specific
+        # fields.
+        self.config = apply_config_file_args(overrides)
+        
+        # Make a container runner for running tools
+        self.runner = ContainerRunner(container_tool_map=get_container_tool_map(
+            self.config))
+        
+        if out_store is not None:
+            # We want to dump files to an IOStore
+            # Make it an absolute path while we're getting set up.
+            self.out_store_string = IOStore.absolute(out_store)
+            
+            # Make sure it works by writing some data to it
+            f = tempfile.NamedTemporaryFile(delete=True)
+            now = datetime.datetime.now()
+            f.write('{}\ntoil-vg version {}\nConfiguration:'.format(now,
+                pkg_resources.get_distribution('toil-vg').version))
+                
+            for key, val in self.config.__dict__.items():
+                f.write('{}: {}\n'.format(key, val))
+            f.flush()
+            self.get_out_store().write_output_file(f.name, 'toil-vg-info.txt')
+            f.close()
+            
+        else:
+            # We don't want to use an out store
+            self.out_store_string = None
+            
+    def get_out_store(self):
+        """
+        Return the IOStore to write output files to, or None if they should not
+        be written anywhere besides the Toil file store.
+        """
+        
+        if self.out_store_string is not None:
+            return IOStore.get(self.out_store_string)
+        else:
+            return None
+            
+    def to_options(self, options):
+        """
+        Turn back into an options-format namespace like toil-vg used to use
+        everywhere. Merges with the given real command-line options.
+        """
+        
+        for key, val in self.config.__dict__.items():
+            # Copy over everything from the config to the options namespace.
+            # Anything in the config that needed to be overridden by command
+            # line options already was overridden in the constructor.
+            options.__dict__[key] = val
+
+        # Save the other aspects of the context into the options under their old
+        # names.
+        options.out_store = self.out_store_string
+        options.drunner = self.runner
+        
+        return options
+        
+        
+        
+        
+        

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -262,27 +262,6 @@ def clean_toil_path(path):
     else:
         return path
 
-def init_out_store(options, command):
-    """
-    Write a little bit of logging to the output store.
-    
-    Rely on IOStore to create the store if it doesn't exist
-    as well as to check its a valid location. 
-
-    Do this at very beginning to avoid finding an outstore issue
-    after hours spent computing
-     
-    """
-    f = tempfile.NamedTemporaryFile(delete=True)
-    now = datetime.datetime.now()
-    f.write('{}\ntoil-vg {} version {}\nOptions:'.format(now, command,
-                    pkg_resources.get_distribution('toil-vg').version))
-    for key,val in options.__dict__.items():
-        f.write('{}: {}\n'.format(key, val))
-    f.flush()
-    IOStore.get(options.out_store).write_output_file(f.name, 'toil-vg-{}.txt'.format(command))
-    f.close()
-
 def import_to_store(toil, options, path, use_out_store = None,
                     out_store_key = None):
     """

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -19,6 +19,21 @@ from toil_vg.iostore import IOStore
 
 logger = logging.getLogger(__name__)
 
+def test_docker():
+    """
+    Return true if Docker is available on this machine, and False otherwise.
+    """
+    
+    try:
+        # Run Docker
+        # TODO: implement around dockerCall somehow?
+        subprocess.check_call(['docker', 'version'])
+        # And report that it worked
+        return True
+    except:
+        # It didn't work, so we can't use Docker
+        return False
+
 def add_container_tool_parse_args(parser):
     """ centralize shared container options and their defaults """
 

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -14,7 +14,7 @@ import getpass
 import pdb
 import textwrap
 import yaml
-from toil_vg.vg_common import require
+from toil_vg.vg_common import require, test_docker
 
 default_config = textwrap.dedent("""
 # Toil VG Pipeline configuration file (created by toil-vg generate-config)
@@ -112,7 +112,7 @@ force-outstore: False
 
 # Toggle container support.  Valid values are Docker / Singularity / None
 # (commenting out or Null values equivalent to None)
-container: Docker
+container: """ + ("Docker" if test_docker() else "None") + """
 
 #############################
 ### Docker Tool Arguments ###
@@ -329,7 +329,7 @@ force-outstore: False
 
 # Toggle container support.  Valid values are Docker / Singularity / None
 # (commenting out or Null values equivalent to None)
-container: Docker
+container: """ + ("Docker" if test_docker() else "None") + """
 
 #############################
 ### Docker Tool Arguments ###

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -33,6 +33,7 @@ from toil_vg.vg_vcfeval import *
 from toil_vg.vg_config import *
 from toil_vg.vg_sim import *
 from toil_vg.vg_mapeval import *
+from toil_vg.context import Context
 
 logger = logging.getLogger(__name__)
 
@@ -275,34 +276,24 @@ def main():
         config_main(args)
         return
 
-    # Else we merge in our config file args with the command line args for
-    # whatever subparser we're in
-    options = apply_config_file_args(args)
-
-    # Relative outstore paths can end up who-knows-where.  Make absolute.
-    if options.out_store[0] == '.':
-        options.out_store = os.path.abspath(options.out_store)
-
+    # Otherwise, we are going to run an actual Toil pipeline
+    # Get a context so we can use the toil-vg library
+    context = Context(args.out_store, args)
+    
     if args.command == 'vcfeval':
-        vcfeval_main(options)
-        return
-
-    # Make sure the output store exists and is valid, and through
-    # a little record of the command line options and version inside it. 
-    init_out_store(options, args.command)
-
-    if args.command == 'run':
-        pipeline_main(options)
+        vcfeval_main(context.to_options(args))
+    elif args.command == 'run':
+        pipeline_main(context.to_options(args))
     elif args.command == 'index':
-        index_main(options)
+        index_main(context.to_options(args))
     elif args.command == 'map':
-        map_main(options)
+        map_main(context.to_options(args))
     elif args.command == 'call':
-        call_main(options)
+        call_main(context.to_options(args))
     elif args.command == 'sim':
-        sim_main(options)
+        sim_main(context.to_options(args))
     elif args.command == 'mapeval':
-        mapeval_main(options)
+        mapeval_main(context.to_options(args))
         
     
 def pipeline_main(options):


### PR DESCRIPTION
Now instead of just cramming everything into the options, we have a toil-vg `Context` that keeps track of the toil-vg configuration (from the config file, and potentially separate from the command-line options), the ContainerRunner, and the out_store (if an out_store is being used).

Instead of passing options to everything, I'm planning to pass just this context object. Then I'll limit the use of actual command-line options to some top-level driver scripts, and refactor all the vg-wrapping Toil jobs to work just based on actual Toil job arguments.

To keep the command-line options that *aren't* configuration overrides out of the config `Namespace`, and to keep the config overrides out of the real command-line options, I'm eventually going to have to do some `argparse` hacking.

For now this is all backwards-compatible, and I'm going to swap things over to the new system piece by piece.