### PR TITLE
Continue refactoring mapeval and IO store usage

### DIFF
--- a/src/toil_vg/context.py
+++ b/src/toil_vg/context.py
@@ -92,6 +92,7 @@ class Context(object):
         # names.
         options.out_store = self.out_store_string
         options.drunner = self.runner
+        options.tool = 'library'
         
         return options
         

--- a/src/toil_vg/context.py
+++ b/src/toil_vg/context.py
@@ -12,6 +12,7 @@ namespace, we keep them both in here.
 import tempfile
 import datetime
 import pkg_resources
+import copy
 
 from argparse import Namespace
 from toil_vg.vg_config import apply_config_file_args
@@ -76,11 +77,34 @@ class Context(object):
         else:
             return None
             
+    def write_file(self, job, path):
+        """
+        
+        Write the file at the given path to the given job's Toil FileStore, and
+        to the out_store if one is in use.
+        
+        In the out_store, the file is saved under its basename, in the root
+        directory.
+        
+        Returns the Toil file ID for the written file.
+        """
+        
+        out_store = self.get_out_store()
+        if out_store is not None:
+            # Save to the out_store if it exists
+            out_store.write_output_file(path, os.path.basename(path))
+        
+        # Save to Toil
+        return job.fileStore.writeGlobalFile(path)
+            
     def to_options(self, options):
         """
         Turn back into an options-format namespace like toil-vg used to use
         everywhere. Merges with the given real command-line options.
         """
+        
+        # Copy the options
+        options = copy.deepcopy(options)
         
         for key, val in self.config.__dict__.items():
             # Copy over everything from the config to the options namespace.

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -269,8 +269,8 @@ def get_files_by_file_size(dirname, reverse=False):
 
     return filepaths
 
-def clean_toil_path(path):
-    """ Try to make input path into something toil friendly """
+def make_url(path):
+    """ Turn filenames into URLs, whileleaving existing URLs alone """
     # local path
     if ':' not in path:
         return 'file://' + os.path.abspath(path)
@@ -299,7 +299,7 @@ def import_to_store(toil, options, path, use_out_store = None,
     if use_out_store is True or (use_out_store is None and options.force_outstore is True):
         return  write_to_store(None, options, path, use_out_store, out_store_key)
     else:
-        return toil.importFile(clean_toil_path(path))
+        return toil.importFile(make_url(path))
     
 def write_to_store(job, options, path, use_out_store = None,
                    out_store_key = None):

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -304,48 +304,36 @@ def import_to_store(toil, options, path, use_out_store = None,
 def write_to_store(job, options, path, use_out_store = None,
                    out_store_key = None):
     """
-    Writes path into the File or IO store (from options.out_store)
-
-    Abstract all store writing here so we can switch to the out_store
-    when we want to checkpoint an intermeidate file for output
-    or just have all intermediate files in the outstore for debugging.
+    Write a file to the Toil filestore.
     
-    Returns the id in job's file store if use_out_store is True
-    otherwise a key (up to caller to make sure its unique)
-    in the out_store
+    If use_out_store is True, or options.force_outstore is True, the file will
+    also be written to the IOStore specified by options.out_store.
+    
+    Returns the id that the file was written to in the Toil FileStore.
 
-    By default options.force_outstore is used to toggle between file and 
-    i/o store.  This will be over-ridden by the use_out_store parameter 
-    if the latter is not None
     """
     if use_out_store is True or (use_out_store is None and options.force_outstore is True):
+        # Sometimes write to the outstore
         out_store = IOStore.get(options.out_store)
         key = os.path.basename(path) if out_store_key is None else out_store_key
         out_store.write_output_file(path, key)
-        return key
-    else:
-        return job.fileStore.writeGlobalFile(path)
+        
+    # Always write to the FileStore
+    return job.fileStore.writeGlobalFile(path)
 
-def read_from_store(job, options, id_or_key, path = None, use_out_store = None):
+def read_from_store(job, options, file_id, path = None, use_out_store = None):
     """
-    Reads id (or key) from the File store (or IO store from options.out_store) into path
-
-    Abstract all store reading here so we can switch to the out_store
-    when we want to checkpoint an intermeidate file for output
-    or just have all intermediate files in the outstore for debugging.
-
-    By default options.force_outstore is used to toggle between file and 
-    i/o store.  This will be over-ridden by the use_out_store parameter 
-    if the latter is not None
+    
+    Read the file with the given Toil file ID from the Toil file store and save
+    it as the given path. If no path is specified, one will be provided.
+    
+    use_out_store is ignored.
+    
+    All usages of this function should be replaced with
+    job.fileStore.readGlobalFile.
+    
     """
-    if use_out_store is True or (use_out_store is None and options.force_outstore is True):
-        # we can add this interface if we really want by coming up
-        # with unique name here, i guess
-        assert path is not None
-        out_store = IOStore.get(options.out_store)
-        return out_store.read_input_file(id_or_key, path)
-    else:
-        return job.fileStore.readGlobalFile(id_or_key, path)
+    return job.fileStore.readGlobalFile(file_id, path)
 
 def write_dir_to_store(job, options, path, use_out_store = None):
     """

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -59,9 +59,9 @@ def map_subparser(parser):
 
 def map_parse_args(parser, stand_alone = False):
     """ centralize indexing parameters here """
-    parser.add_argument("--fastq", nargs='+', 
+    parser.add_argument("--fastq", nargs='+', type=make_url,
                         help="Input fastq (possibly compressed), two are allowed, one for each mate")
-    parser.add_argument("--gam_input_reads", default=None,
+    parser.add_argument("--gam_input_reads", type=make_url, default=None,
                         help="Input reads in GAM format")
     parser.add_argument("--single_reads_chunk", action="store_true", default=False,
                         help="do not split reads into chunks")

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -293,7 +293,7 @@ def main():
     elif args.command == 'sim':
         sim_main(context.to_options(args))
     elif args.command == 'mapeval':
-        mapeval_main(context.to_options(args))
+        mapeval_main(context, args)
         
     
 def pipeline_main(options):


### PR DESCRIPTION
Now mapeval makes some use of the new Context object.

I've also swapped out the IO-store-wrapping functions with versions that always write to the Toil filestore, and also, if possible, always save to (but don't load from) the out_store. This might result in a lot of stuff being dumped to the out_store.