### PR TITLE
Put Toil Autoscaling examples in README

### DIFF
--- a/bakeoff.sh
+++ b/bakeoff.sh
@@ -97,7 +97,9 @@ if [ "$MESOS" == "1" ]; then
 	 JOB_STORE="aws:us-west-2:${PREFIX}-bakeoff-job-store"
 	 OUT_STORE="aws:us-west-2:${PREFIX}-bakeoff-out-store"
 	 CP_OUT_STORE="s3://${PREFIX}-bakeoff-out-store"
-	 BS_OPTS="--batchSystem=mesos --mesosMaster=mesos-master:5050"
+	 PRIVATE_IP=`ifconfig eth0 |grep "inet addr" |awk '{print $2}' |awk -F: '{print $2}'`
+	 # To use spot notes, add: --defaultPreemptable --preemptableNodeType c3.8xlarge:0.85
+	 BS_OPTS="--batchSystem=mesos --mesosMaster=${PRIVATE_IP}:5050 --nodeType c3.8xlarge --retry 4 --provisioner aws --minNodes 0 --maxNodes 2"
 	 CP_CMD="aws s3 cp"
 	 RM_CMD="aws s3 rm"
 else


### PR DESCRIPTION
cgcloud's all but dead now, so instead use Toil's aws provisioner in README examples for running on cloud (old cgcloud docs still kept at bottom for now). 

I haven't actually run much whole-genome stuff on the autoscaler yet, so some of the command lines will probably need correcting as I do.  But they're still more helpful than the cgcloud docs at this point. 

There's also the question of identifying which jobs are/aren't preemptable.  Right now assuming everything is, but we'll probably want a mix to run smoothly on big runs at more aggressive spot prices. 