### PR TITLE
Continue refactoring mapeval

### DIFF
--- a/src/toil_vg/context.py
+++ b/src/toil_vg/context.py
@@ -15,9 +15,14 @@ import pkg_resources
 import copy
 
 from argparse import Namespace
+
+from toil.common import Toil
+from toil.job import Job
+
 from toil_vg.vg_config import apply_config_file_args
 from toil_vg.vg_common import ContainerRunner, get_container_tool_map
 from toil_vg.iostore import IOStore
+
 
 class Context(object):
     """
@@ -28,7 +33,7 @@ class Context(object):
         """
         Make a new context, so we can run the library.
         
-        Takes an optional Namespace of overrides for default toil-vg
+        Takes an optional Namespace of overrides for default toil-vg and Toil
         configuration values.
         
         Overrides can also have a "config" key, in which case that config file
@@ -65,6 +70,25 @@ class Context(object):
         else:
             # We don't want to use an out store
             self.out_store_string = None
+    
+    def get_toil(self, job_store):
+        """
+        Produce a new Toil object for running Toil jobs, using the configuration
+        used when constructing this context, and the given job_store specifier.
+        
+        Needs to be used in a "with" statement to actually work.
+        """
+        
+        # Get the default Toil options
+        toil_options = Job.Runner.getDefaultOptions(job_store)
+        
+        for k, v in self.config.__dict__.iteritems():
+            # Blit over all the overrides, some of which will be relevant
+            toil_options.__dict__[k] = v
+        
+        # Make the Toil object and return it.
+        # It still needs to be entered as a context manager in order to be used.
+        return Toil(toil_options)
             
     def get_out_store(self):
         """

--- a/src/toil_vg/context.py
+++ b/src/toil_vg/context.py
@@ -13,6 +13,8 @@ import tempfile
 import datetime
 import pkg_resources
 import copy
+import os
+import os.path
 
 from argparse import Namespace
 
@@ -101,7 +103,27 @@ class Context(object):
         else:
             return None
             
-    def write_file(self, job, path):
+    def write_intermediate_file(self, job, path):
+        """
+        Write the file at the given path to the given job's Toil FileStore, and
+        to the out_store if one is in use and we are trying to dump intermediate
+        files.
+        
+        In the out_store, the file is saved under its basename, in the root
+        directory.
+        
+        Returns the Toil file ID for the written file.
+        """
+        
+        out_store = self.get_out_store()
+        if out_store is not None and self.config.force_outstore:
+            # Save to the out_store if it exists
+            out_store.write_output_file(path, os.path.basename(path))
+        
+        # Save to Toil
+        return job.fileStore.writeGlobalFile(path)
+            
+    def write_output_file(self, job, path):
         """
         
         Write the file at the given path to the given job's Toil FileStore, and

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -24,10 +24,13 @@ def test_docker():
     Return true if Docker is available on this machine, and False otherwise.
     """
     
+    # We don't actually want any Docker output.
+    nowhere = open(os.devnull, 'wb')
+    
     try:
         # Run Docker
         # TODO: implement around dockerCall somehow?
-        subprocess.check_call(['docker', 'version'])
+        subprocess.check_call(['docker', 'version'], stdout=nowhere, stderr=nowhere)
         # And report that it worked
         return True
     except:

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -472,7 +472,7 @@ def apply_config_file_args(args):
                     del args.__dict__[x_opts][pos:pos+2]
 
     # If no config file given, we generate a default one
-    if args.config is None:
+    if not args.__dict__.has_key('config') or args.config is None:
         config = generate_config()
     else:
         require(os.path.exists(args.config), 'Config, {}, not found. Please run '

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -178,6 +178,16 @@ def validate_options(options):
     if options.index_bases:
         require(options.gam_names and len(options.index_bases) == len(options.gam_names),
                  '--index-bases and --gam_names must have same number of inputs')
+                 
+    # Make sure names are unique so we can use them as dict keys and file names
+    names = []
+    if options.bam_names:
+        names += options.bam_names
+    if options.pe_bam_names:
+        names += options.pe_bam_names
+    if options.gam_names:
+        names += options.gam_names
+    require(len(names) == len(set(names)), 'all names must be unique')
     
 def parse_int(value):
     """
@@ -824,9 +834,8 @@ def run_process_position_comparisons(job, context, options, names, compare_ids):
                     # TODO: why are we quoting the aligner name here? What parses TSV and respects quotes?
                     out_results.write('{}\t{}\t"{}"\n'.format(toks[1], toks[2], a))
 
-        for i, nci in enumerate(zip(names, compare_ids)):
-            name, compare_id = nci[0], nci[1]
-            compare_file = os.path.join(work_dir, '{}-{}.compare.positions'.format(name, i))
+        for name, compare_id in itertools.izip(names, compare_ids):
+            compare_file = os.path.join(work_dir, '{}.compare.positions'.format(name))
             job.fileStore.readGlobalFile(compare_id, compare_file)
             context.write_output_file(job, compare_file)
             write_tsv(compare_file, name)
@@ -1018,9 +1027,8 @@ def run_process_score_comparisons(job, context, options, names, compare_ids):
                     toks = line.rstrip().split(', ')
                     out_results.line(toks[1], a)
 
-        for i, nci in enumerate(zip(names, compare_ids)):
-            name, compare_id = nci[0], nci[1]
-            compare_file = os.path.join(work_dir, '{}-{}.compare.scores'.format(name, i))
+        for name, compare_id in itertools.izip(names, compare_ids):
+            compare_file = os.path.join(work_dir, '{}.compare.scores'.format(name))
             job.fileStore.readGlobalFile(compare_id, compare_file)
             context.write_output_file(job, compare_file)
             write_tsv(compare_file, name)

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -498,7 +498,7 @@ def compare_scores(job, context, options, baseline_file_id, name, score_file_id)
     read name, contig aligned to, alignment position, alignment score, MAPQ
     
     Produces a CSV (NOT TSV) of the form:
-    read name, score difference
+    read name, score difference, aligned score, baseline score
     
     Uses the given name as a file base name for the file under test.
     """

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -54,15 +54,9 @@ def mapeval_subparser(parser):
     parser.add_argument('out_store',
                         help='output store.  All output written here. Path specified using same syntax as toil jobStore')
     
-    # Add mapeval-spacific stuff
+    # Add mapeval stuff
     add_mapeval_options(parser)
     
-    # Add mapping options
-    map_parse_args(parser)
-
-    # Add common options shared with everybody
-    add_common_vg_parse_args(parser)
-
     # Add common docker options
     add_container_tool_parse_args(parser)
     
@@ -113,6 +107,15 @@ def add_mapeval_options(parser):
     # We can compare all the scores against those from a particular GAM, if asked.
     parser.add_argument('--compare-gam-scores', default=None,
                         help='compare scores against those in the given named GAM')
+                        
+    # We also need to have these options to make lower-level toil-vg code happy
+    # with the options namespace we hand it.
+    
+    # Add mapping options
+    map_parse_args(parser)
+
+    # Add common options shared with everybody
+    add_common_vg_parse_args(parser)
     
 def get_default_mapeval_options(truth):
     """

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -48,9 +48,30 @@ def mapeval_subparser(parser):
     # Add the Toil options so the job store is the first argument
     Job.Runner.addToilOptions(parser)
     
-    # General options
+    # Add the out_store
+    # TODO: do this at a higher level?
+    # Or roll into Context?
     parser.add_argument('out_store',
                         help='output store.  All output written here. Path specified using same syntax as toil jobStore')
+    
+    # Add mapeval-spacific stuff
+    add_mapeval_options(parser)
+    
+    # Add mapping options
+    map_parse_args(parser)
+
+    # Add common options shared with everybody
+    add_common_vg_parse_args(parser)
+
+    # Add common docker options
+    add_container_tool_parse_args(parser)
+    
+def add_mapeval_options(parser):
+    """
+    Add the mapeval-specific options to the given argparse parser.
+    """
+    
+    # General options
     parser.add_argument('truth', type=make_url, default=None,
                         help='list of true positions of reads as output by toil-vg sim')        
     parser.add_argument('--gams', nargs='+', type=make_url, default=[],
@@ -93,14 +114,22 @@ def mapeval_subparser(parser):
     parser.add_argument('--compare-gam-scores', default=None,
                         help='compare scores against those in the given named GAM')
     
-    # Add mapping options
-    map_parse_args(parser)
-
-    # Add common options shared with everybody
-    add_common_vg_parse_args(parser)
-
-    # Add common docker options
-    add_container_tool_parse_args(parser)
+def get_default_mapeval_options():
+    """
+    Return an argparse Namespace populated with the default mapeval option
+    values.
+    
+    Can be modified and then passed to make_mapeval_plan(), so you can use
+    mapeval as part of a larger program.
+    
+    """
+    
+    # Make a parser
+    parser = argparse.ArgumentParser()
+    # Stick our arguments on it
+    add_mapeval_options(parser)
+    # And parse nothing but mandatory arguments
+    return parser.parse_args([])
     
 def validate_options(options):
     """

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -114,10 +114,12 @@ def add_mapeval_options(parser):
     parser.add_argument('--compare-gam-scores', default=None,
                         help='compare scores against those in the given named GAM')
     
-def get_default_mapeval_options():
+def get_default_mapeval_options(truth):
     """
     Return an argparse Namespace populated with the default mapeval option
     values.
+    
+    Requires the required positional truth file argument.
     
     Can be modified and then passed to make_mapeval_plan(), so you can use
     mapeval as part of a larger program.
@@ -129,7 +131,7 @@ def get_default_mapeval_options():
     # Stick our arguments on it
     add_mapeval_options(parser)
     # And parse nothing but mandatory arguments
-    return parser.parse_args([])
+    return parser.parse_args([truth])
     
 def validate_options(options):
     """


### PR DESCRIPTION
Now everything in mapeval uses the context, and I'm ready to mostly remove the options being passed around (except to the top-level orchestration function).

I'm still trying to work out a good way to let user code synthesize an options namespace when invoking mapeval as a library; I have a function to get a default set of options right now, given only the required arguments, kind of like Toil uses when you want a Toil instance but aren't using argparse.

I think I want to tweak that a bit, though, because I want to be able to get the default options and use them while feeding in inputs by Toil file ID. Maybe I need to engineer a separation between script-level configuration and input sources, or alternatively just run all of the possible analyses given the available inputs.